### PR TITLE
Lots of tweaks to the osu! embeds

### DIFF
--- a/youmubot-osu/src/discord/embeds.rs
+++ b/youmubot-osu/src/discord/embeds.rs
@@ -259,7 +259,6 @@ pub(crate) fn score_embed<'a>(
             s.date.format("%F %T"),
         ))
         .image(b.cover_url())
-        .field("Map stats", diff.format_info(mode, s.mods, b), false)
         .field(
             "Score stats",
             format!(
@@ -278,6 +277,7 @@ pub(crate) fn score_embed<'a>(
             ),
             true,
         )
+        .field("Map stats", diff.format_info(mode, s.mods, b), false)
         .timestamp(&s.date);
     if mode.to_oppai_mode().is_none() && s.mods != Mods::NOMOD {
         m.footer(|f| f.text("Star difficulty does not reflect game mods."));

--- a/youmubot-osu/src/discord/embeds.rs
+++ b/youmubot-osu/src/discord/embeds.rs
@@ -301,31 +301,40 @@ pub(crate) fn user_embed<'a>(
                 .unwrap_or("Inactive".to_owned()),
             false,
         )
-        .field("World Rank", format!("#{}", u.rank), true)
+        .field("World Rank", format!("#{}", grouped_number(u.rank)), true)
         .field(
             "Country Rank",
-            format!(":flag_{}: #{}", u.country.to_lowercase(), u.country_rank),
+            format!(":flag_{}: #{}", u.country.to_lowercase(), grouped_number(u.country_rank)),
             true,
         )
         .field("Accuracy", format!("{:.2}%", u.accuracy), true)
         .field(
-            "Play count",
-            format!("{} (play time: {})", u.play_count, Duration(u.played_time)),
+            "Play count / Play time",
+            format!(
+                "{} ({})",
+                grouped_number(u.play_count),
+                Duration(u.played_time)
+            ),
             false,
         )
         .field(
             "Ranks",
             format!(
-                "{} SSH | {} SS | {} SH | {} S | {} A",
-                u.count_ssh, u.count_ss, u.count_sh, u.count_s, u.count_a
+                "**{}** SSH | **{}** SS | **{}** SH | **{}** S | **{}** A",
+                grouped_number(u.count_ssh),
+                grouped_number(u.count_ss),
+                grouped_number(u.count_sh),
+                grouped_number(u.count_s),
+                grouped_number(u.count_a)
             ),
             false,
         )
         .field(
-            "Level",
+            format!("Level {:.0}", u.level),
             format!(
-                "Level **{:.0}**: {} total score, {} ranked score",
-                u.level, u.total_score, u.ranked_score
+                "**{}** total score, **{}** ranked score",
+                grouped_number(u.total_score),
+                grouped_number(u.ranked_score)
             ),
             false,
         )
@@ -348,13 +357,14 @@ pub(crate) fn user_embed<'a>(
                         )
                     ))
                     .push("on ")
-                    .push(format!(
-                        "[{} - {}]({})",
+                    .push_line(format!(
+                        "[{} - {} [{}]]({})**{} **",
                         MessageBuilder::new().push_bold_safe(&map.artist).build(),
                         MessageBuilder::new().push_bold_safe(&map.title).build(),
-                        map.link()
+                        map.difficulty_name,
+                        map.link(),
+                        v.mods
                     ))
-                    .push_line(format!(" [{}]", map.difficulty_name))
                     .push(format!(
                         "{:.1}⭐ | `{}`",
                         info.map(|i| i.stars as f64).unwrap_or(map.difficulty.stars),

--- a/youmubot-osu/src/discord/embeds.rs
+++ b/youmubot-osu/src/discord/embeds.rs
@@ -219,6 +219,19 @@ pub(crate) fn score_embed<'a>(
     } else {
         pp.map(|v| v.1)
     };
+    let pp_gained = s.pp.map(|full_pp| {
+        top_record
+            .map(|top| {
+                let after_pp = u.pp.unwrap();
+                let effective_pp = full_pp * (0.95f64).powi(top as i32);
+                let before_pp = after_pp - effective_pp;
+                format!(
+                    "**pp gained**: **{:.2}**pp (+**{:.2}**pp | {:.2}pp \\➡️ {:.2}pp)",
+                    full_pp, effective_pp, before_pp, after_pp
+                )
+            })
+            .unwrap_or_else(|| format!("**pp gained**: **{:.2}**pp", full_pp))
+    });
     let score_line = pp
         .map(|pp| format!("{} | {}", &score_line, pp))
         .unwrap_or(score_line);
@@ -248,7 +261,8 @@ pub(crate) fn score_embed<'a>(
         .description(format!(
             r#"**Beatmap**: {} - {} [{}]**{} **
 **Links**: [[Listing]]({}) [[Download]]({}) [[Bloodcat]]({})
-**Played on**: {}"#,
+**Played on**: {}
+{}"#,
             b.artist,
             b.title,
             b.difficulty_name,
@@ -257,6 +271,7 @@ pub(crate) fn score_embed<'a>(
             b.download_link(false),
             b.download_link(true),
             s.date.format("%F %T"),
+            pp_gained.as_ref().map(|v| &v[..]).unwrap_or(""),
         ))
         .image(b.cover_url())
         .field(
@@ -304,7 +319,11 @@ pub(crate) fn user_embed<'a>(
         .field("World Rank", format!("#{}", grouped_number(u.rank)), true)
         .field(
             "Country Rank",
-            format!(":flag_{}: #{}", u.country.to_lowercase(), grouped_number(u.country_rank)),
+            format!(
+                ":flag_{}: #{}",
+                u.country.to_lowercase(),
+                grouped_number(u.country_rank)
+            ),
             true,
         )
         .field("Accuracy", format!("{:.2}%", u.accuracy), true)

--- a/youmubot-osu/src/discord/hook.rs
+++ b/youmubot-osu/src/discord/hook.rs
@@ -20,13 +20,13 @@ use super::embeds::{beatmap_embed, beatmapset_embed};
 
 lazy_static! {
     static ref OLD_LINK_REGEX: Regex = Regex::new(
-        r"https?://osu\.ppy\.sh/(?P<link_type>s|b)/(?P<id>\d+)(?:[\&\?]m=(?P<mode>\d))?(?:\+(?P<mods>[A-Z]+))?"
+        r"(?:https?://)?osu\.ppy\.sh/(?P<link_type>s|b)/(?P<id>\d+)(?:[\&\?]m=(?P<mode>\d))?(?:\+(?P<mods>[A-Z]+))?"
     ).unwrap();
     static ref NEW_LINK_REGEX: Regex = Regex::new(
-        r"https?://osu\.ppy\.sh/beatmapsets/(?P<set_id>\d+)/?(?:\#(?P<mode>osu|taiko|fruits|mania)(?:/(?P<beatmap_id>\d+)|/?))?(?:\+(?P<mods>[A-Z]+))?"
+        r"(?:https?://)?osu\.ppy\.sh/beatmapsets/(?P<set_id>\d+)/?(?:\#(?P<mode>osu|taiko|fruits|mania)(?:/(?P<beatmap_id>\d+)|/?))?(?:\+(?P<mods>[A-Z]+))?"
     ).unwrap();
     static ref SHORT_LINK_REGEX: Regex = Regex::new(
-        r"/b/(?P<id>\d+)(?:/(?P<mode>osu|taiko|fruits|mania))?(?:\+(?P<mods>[A-Z]+))?"
+        r"(?:^|\s)/b/(?P<id>\d+)(?:/(?P<mode>osu|taiko|fruits|mania))?(?:\+(?P<mods>[A-Z]+))?"
     ).unwrap();
 }
 

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -122,11 +122,6 @@ pub fn mania(ctx: &mut Context, msg: &Message, args: Args) -> CommandResult {
 pub(crate) struct BeatmapWithMode(pub Beatmap, pub Mode);
 
 impl BeatmapWithMode {
-    /// Whether this beatmap-with-mode is a converted beatmap.
-    fn is_converted(&self) -> bool {
-        self.0.mode != self.1
-    }
-
     fn mode(&self) -> Mode {
         self.1
     }

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -2,12 +2,14 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::Duration;
+use youmubot_prelude::Duration as YoumuDuration;
 
 pub mod mods;
 pub mod parse;
 pub(crate) mod raw;
 
 pub use mods::Mods;
+use serenity::utils::MessageBuilder;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum ApprovalStatus {
@@ -117,6 +119,40 @@ impl Difficulty {
         }
 
         diff
+    }
+
+    /// Format the difficulty info into a short summary.
+    pub fn format_info(&self, mode: Mode, mods: Mods, original_beatmap: &Beatmap) -> String {
+        MessageBuilder::new()
+            .push(format!(
+                "[[Link]]({}) (`{}`)",
+                original_beatmap.link(),
+                original_beatmap.short_link(Some(mode), Some(mods))
+            ))
+            .push(", ")
+            .push_bold(format!("{:.2}⭐", self.stars))
+            .push(", ")
+            .push_bold_line(format_mode(mode, original_beatmap.mode))
+            .push("CS")
+            .push_bold(format!("{:.1}", self.cs))
+            .push(", AR")
+            .push_bold(format!("{:.1}", self.ar))
+            .push(", OD")
+            .push_bold(format!("{:.1}", self.od))
+            .push(", HP")
+            .push_bold(format!("{:.1}", self.hp))
+            .push(format!(", BPM**{}**", self.bpm))
+            .push(", ⌛ ")
+            .push_bold(format!("{}", YoumuDuration(self.drain_length)))
+            .build()
+    }
+}
+
+fn format_mode(actual: Mode, original: Mode) -> String {
+    if actual == original {
+        format!("{}", actual)
+    } else {
+        format!("{} (converted)", actual)
     }
 }
 

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -94,8 +94,11 @@ impl Difficulty {
     }
     /// Apply mods to the given difficulty.
     /// Note that `stars`, `aim` and `speed` cannot be calculated from this alone.
-    pub fn apply_mods(&self, mods: Mods) -> Difficulty {
-        let mut diff = self.clone();
+    pub fn apply_mods(&self, mods: Mods, updated_stars: Option<f64>) -> Difficulty {
+        let mut diff = Difficulty {
+            stars: updated_stars.unwrap_or(self.stars),
+            ..self.clone()
+        };
 
         // Apply mods one by one
         if mods.contains(Mods::EZ) {
@@ -132,6 +135,13 @@ impl Difficulty {
             .push(", ")
             .push_bold(format!("{:.2}⭐", self.stars))
             .push(", ")
+            .push(
+                original_beatmap
+                    .difficulty
+                    .max_combo
+                    .map(|c| format!("max **{}x**, ", c))
+                    .unwrap_or_else(|| "".to_owned()),
+            )
             .push_bold_line(format_mode(mode, original_beatmap.mode))
             .push("CS")
             .push_bold(format!("{:.1}", self.cs))
@@ -311,6 +321,18 @@ impl Beatmap {
             "https://osu.ppy.sh/beatmapsets/{}#{}/{}",
             self.beatmapset_id, NEW_MODE_NAMES[self.mode as usize], self.beatmap_id
         )
+    }
+
+    /// Returns a direct download link. If `bloodcat` is true, return the bloodcat download link.
+    pub fn download_link(&self, bloodcat: bool) -> String {
+        if bloodcat {
+            format!("https://bloodcat.com/osu/s/{}", self.beatmapset_id)
+        } else {
+            format!(
+                "https://osu.ppy.sh/beatmapsets/{}/download",
+                self.beatmapset_id
+            )
+        }
     }
 
     /// Return a parsable short link.

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -126,13 +126,18 @@ impl Difficulty {
 
     /// Format the difficulty info into a short summary.
     pub fn format_info(&self, mode: Mode, mods: Mods, original_beatmap: &Beatmap) -> String {
+        let is_not_ranked = match original_beatmap.approval {
+            ApprovalStatus::Ranked(_) => false,
+            _ => true,
+        };
+        let three_lines = is_not_ranked;
         MessageBuilder::new()
             .push(format!(
                 "[[Link]]({}) (`{}`)",
                 original_beatmap.link(),
                 original_beatmap.short_link(Some(mode), Some(mods))
             ))
-            .push(", ")
+            .push(if three_lines { "\n" } else { ", " })
             .push_bold(format!("{:.2}⭐", self.stars))
             .push(", ")
             .push(
@@ -142,6 +147,11 @@ impl Difficulty {
                     .map(|c| format!("max **{}x**, ", c))
                     .unwrap_or_else(|| "".to_owned()),
             )
+            .push(if is_not_ranked {
+                format!("status **{}**, mode ", original_beatmap.approval)
+            } else {
+                "".to_owned()
+            })
             .push_bold_line(format_mode(mode, original_beatmap.mode))
             .push("CS")
             .push_bold(format!("{:.1}", self.cs))

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -131,6 +131,7 @@ impl Difficulty {
             _ => true,
         };
         let three_lines = is_not_ranked;
+        let bpm = (self.bpm * 100.0).round() / 100.0;
         MessageBuilder::new()
             .push(format!(
                 "[[Link]]({}) (`{}`)",
@@ -161,7 +162,7 @@ impl Difficulty {
             .push_bold(format!("{:.1}", self.od))
             .push(", HP")
             .push_bold(format!("{:.1}", self.hp))
-            .push(format!(", BPM**{}**", self.bpm))
+            .push(format!(", BPM**{}**", bpm))
             .push(", ⌛ ")
             .push_bold(format!("{}", YoumuDuration(self.drain_length)))
             .build()


### PR DESCRIPTION
- Add missing genres and languages
- Chmod +x youmubot before starting
- Overhaul reaction handler to a thread spawning model (#2)
- Cache by rustc hash (#3)
- Simplify beatmap embed information
- Shrink embeds!!
- Put ranked status on information
- Paint the user embed!
- Add gained pp
- Use more carefully crafted hooks
- 'JSformat' the bpm float

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/youmubot/4)
<!-- Reviewable:end -->
