### PR TITLE
`osu updatelb` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1900,6 +1900,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
+ "dashmap",
  "flume",
  "futures-util",
  "reqwest",

--- a/youmubot-cf/src/lib.rs
+++ b/youmubot-cf/src/lib.rs
@@ -172,7 +172,7 @@ pub async fn ranks(ctx: &Context, m: &Message) -> CommandResult {
     let total_pages = (ranks.len() + ITEMS_PER_PAGE - 1) / ITEMS_PER_PAGE;
     let last_updated = ranks.iter().map(|(_, cfu)| cfu.last_update).min().unwrap();
 
-    paginate(
+    paginate_fn(
         move |page, ctx, msg| {
             let ranks = ranks.clone();
             Box::pin(async move {
@@ -301,7 +301,7 @@ pub async fn contestranks(ctx: &Context, m: &Message, mut args: Args) -> Command
     const ITEMS_PER_PAGE: usize = 10;
     let total_pages = (ranks.len() + ITEMS_PER_PAGE - 1) / ITEMS_PER_PAGE;
 
-    paginate(
+    paginate_fn(
         move |page, ctx, msg| {
             let contest = contest.clone();
             let problems = problems.clone();

--- a/youmubot-core/src/community/roles.rs
+++ b/youmubot-core/src/community/roles.rs
@@ -33,7 +33,7 @@ async fn list(ctx: &Context, m: &Message, _: Args) -> CommandResult {
             const ROLES_PER_PAGE: usize = 8;
             let pages = (roles.len() + ROLES_PER_PAGE - 1) / ROLES_PER_PAGE;
 
-            paginate(
+            paginate_fn(
                 |page, ctx, msg| {
                     let roles = roles.clone();
                     Box::pin(async move {

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -29,7 +29,7 @@ use db::OsuUser;
 use db::{OsuLastBeatmap, OsuSavedUsers, OsuUserBests};
 use embeds::{beatmap_embed, score_embed, user_embed};
 pub use hook::hook;
-use server_rank::{LEADERBOARD_COMMAND, SERVER_RANK_COMMAND};
+use server_rank::{LEADERBOARD_COMMAND, SERVER_RANK_COMMAND, UPDATE_LEADERBOARD_COMMAND};
 
 /// The osu! client.
 pub(crate) struct OsuClient;
@@ -89,7 +89,8 @@ pub fn setup(
     check,
     top,
     server_rank,
-    leaderboard
+    leaderboard,
+    update_leaderboard
 )]
 #[default_command(std)]
 struct Osu;

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -59,6 +59,11 @@ pub fn setup(
     OsuLastBeatmap::insert_into(&mut *data, &path.join("last_beatmaps.yaml"))?;
     OsuUserBests::insert_into(&mut *data, &path.join("osu_user_bests.yaml"))?;
 
+    // Locks
+    data.insert::<server_rank::update_lock::UpdateLock>(
+        server_rank::update_lock::UpdateLock::default(),
+    );
+
     // API client
     let http_client = data.get::<HTTPClient>().unwrap().clone();
     let osu_client = Arc::new(OsuHttpClient::new(

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -247,7 +247,7 @@ async fn list_plays<'a>(
 
     const ITEMS_PER_PAGE: usize = 5;
     let total_pages = (plays.len() + ITEMS_PER_PAGE - 1) / ITEMS_PER_PAGE;
-    paginate(
+    paginate_fn(
         move |page, ctx, msg| {
             let plays = plays.clone();
             Box::pin(async move {

--- a/youmubot-osu/src/discord/server_rank.rs
+++ b/youmubot-osu/src/discord/server_rank.rs
@@ -55,7 +55,7 @@ pub async fn server_rank(ctx: &Context, m: &Message, mut args: Args) -> CommandR
 
     let users = std::sync::Arc::new(users);
     let last_update = last_update.unwrap();
-    paginate(
+    paginate_fn(
         move |page: u8, ctx: &Context, m: &mut Message| {
             const ITEMS_PER_PAGE: usize = 10;
             let users = users.clone();
@@ -192,7 +192,7 @@ pub async fn leaderboard(ctx: &Context, m: &Message, mut _args: Args) -> Command
         .await?;
         return Ok(());
     }
-    paginate(
+    paginate_fn(
         move |page: u8, ctx: &Context, m: &mut Message| {
             const ITEMS_PER_PAGE: usize = 5;
             let start = (page as usize) * ITEMS_PER_PAGE;

--- a/youmubot-prelude/Cargo.toml
+++ b/youmubot-prelude/Cargo.toml
@@ -15,6 +15,7 @@ youmubot-db = { path = "../youmubot-db" }
 reqwest = "0.10"
 chrono = "0.4"
 flume = "0.9"
+dashmap = "3"
 
 [dependencies.serenity]
 version = "0.9"

--- a/youmubot-prelude/src/lib.rs
+++ b/youmubot-prelude/src/lib.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 pub mod announcer;
 pub mod args;
 pub mod hook;
+pub mod member_cache;
 pub mod pagination;
 pub mod ratelimit;
 pub mod setup;
@@ -13,6 +14,7 @@ pub mod setup;
 pub use announcer::{Announcer, AnnouncerHandler};
 pub use args::{Duration, UsernameArg};
 pub use hook::Hook;
+pub use member_cache::MemberCache;
 pub use pagination::{paginate, paginate_fn};
 
 /// Re-exporting async_trait helps with implementing Announcer.

--- a/youmubot-prelude/src/lib.rs
+++ b/youmubot-prelude/src/lib.rs
@@ -13,7 +13,7 @@ pub mod setup;
 pub use announcer::{Announcer, AnnouncerHandler};
 pub use args::{Duration, UsernameArg};
 pub use hook::Hook;
-pub use pagination::paginate;
+pub use pagination::{paginate, paginate_fn};
 
 /// Re-exporting async_trait helps with implementing Announcer.
 pub use async_trait::async_trait;

--- a/youmubot-prelude/src/member_cache.rs
+++ b/youmubot-prelude/src/member_cache.rs
@@ -1,0 +1,45 @@
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use serenity::model::{
+    guild::Member,
+    id::{GuildId, UserId},
+};
+use serenity::{http::CacheHttp, prelude::*};
+use std::sync::Arc;
+
+const VALID_CACHE_SECONDS: i64 = 15 * 60; // 15 minutes
+
+/// MemberCache resolves `does User belong to Guild` requests, and store them in a cache.
+#[derive(Debug, Default)]
+pub struct MemberCache(DashMap<(UserId, GuildId), (Option<Member>, DateTime<Utc>)>);
+
+impl TypeMapKey for MemberCache {
+    type Value = Arc<MemberCache>;
+}
+
+impl MemberCache {
+    pub async fn query(
+        &self,
+        cache_http: impl CacheHttp,
+        user_id: UserId,
+        guild_id: GuildId,
+    ) -> Option<Member> {
+        let now = Utc::now();
+        // Check cache
+        if let Some(r) = self.0.get(&(user_id, guild_id)) {
+            if &r.1 > &now {
+                return r.0.clone();
+            }
+        }
+        // Query
+        let t = guild_id.member(&cache_http, user_id).await.ok();
+        self.0.insert(
+            (user_id, guild_id),
+            (
+                t.clone(),
+                now + chrono::Duration::seconds(VALID_CACHE_SECONDS),
+            ),
+        );
+        t
+    }
+}

--- a/youmubot-prelude/src/setup.rs
+++ b/youmubot-prelude/src/setup.rs
@@ -11,4 +11,7 @@ pub fn setup_prelude(db_path: &Path, data: &mut TypeMap) {
 
     // Set up the HTTP client.
     data.insert::<crate::HTTPClient>(reqwest::Client::new());
+
+    // Set up the member cache.
+    data.insert::<crate::MemberCache>(std::sync::Arc::new(crate::MemberCache::default()));
 }


### PR DESCRIPTION
Updates the leaderboard. 

To make this happen we had to:
- Make a member cache
- Use that, along with a simple update lock, to implement `updatelb` with minimal API call waste...

Other commands benefit from the member cache as well!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/youmubot/8)
<!-- Reviewable:end -->
