### PR TITLE
osu: add slash command support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "dashmap 5.5.3",
  "futures-util",
  "lazy_static",
+ "poise",
  "rand",
  "regex",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "command_attr"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f08c85a02e066b7b4f7dcb60eee6ae0793ef7d6452a3547d1f19665df070a9"
+checksum = "6fcc89439e1bb4e19050a9586a767781a3060000d2f3296fd2a40597ad9421c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -868,8 +874,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
- "indexmap 2.2.3",
+ "http 0.2.11",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -891,6 +897,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hashlink"
@@ -970,13 +982,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
 ]
 
@@ -1009,7 +1032,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "httparse",
  "httpdate",
@@ -1029,12 +1052,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
+ "http 0.2.11",
  "hyper",
- "rustls",
+ "rustls 0.21.11",
  "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
@@ -1101,12 +1124,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1620,25 +1643,25 @@ checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 [[package]]
 name = "poise"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1819d5a45e3590ef33754abce46432570c54a120798bdbf893112b4211fa09a6"
+source = "git+https://github.com/serenity-rs/poise?branch=current#80a3a9c3ca1629725f0fa4ec98372d39cf36f6b6"
 dependencies = [
  "async-trait",
  "derivative",
  "futures-util",
+ "indexmap 2.7.0",
  "parking_lot",
  "poise_macros",
  "regex",
  "serenity",
  "tokio",
  "tracing",
+ "trim-in-place",
 ]
 
 [[package]]
 name = "poise_macros"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fa2c123c961e78315cd3deac7663177f12be4460f5440dbf62a7ed37b1effea"
+source = "git+https://github.com/serenity-rs/poise?branch=current#80a3a9c3ca1629725f0fa4ec98372d39cf36f6b6"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1761,13 +1784,13 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 0.2.11",
  "http-body",
  "hyper",
  "hyper-rustls",
@@ -1781,7 +1804,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.11",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1790,7 +1813,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -1798,7 +1821,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -1931,8 +1954,22 @@ checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1953,8 +1990,14 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -1963,6 +2006,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2058,6 +2112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cow"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7bbbec7196bfde255ab54b65e34087c0849629280028238e67ee25d6a4b7da"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,13 +2168,13 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.12.0"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385647faa24a889929028973650a4f158fb1b4272b2fcf94feb9fcc3c009e813"
+checksum = "3d72ec4323681bf9a3cabe40fd080abc2435859b502a1b5aa9bf693f125bfa76"
 dependencies = [
  "arrayvec",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.4.2",
  "bytes",
  "chrono",
@@ -2127,6 +2190,7 @@ dependencies = [
  "reqwest",
  "secrecy",
  "serde",
+ "serde_cow",
  "serde_json",
  "static_assertions",
  "time",
@@ -2302,7 +2366,7 @@ dependencies = [
  "futures-util",
  "hashlink",
  "hex",
- "indexmap 2.2.3",
+ "indexmap 2.7.0",
  "log",
  "memchr",
  "once_cell",
@@ -2367,7 +2431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "byteorder",
  "bytes",
@@ -2410,7 +2474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "byteorder",
  "chrono",
@@ -2712,7 +2776,18 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.11",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -2729,17 +2804,18 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tungstenite",
- "webpki-roots",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -2821,6 +2897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
+
+[[package]]
 name = "triomphe"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,18 +2916,19 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
 dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.2.0",
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.57",
  "url",
@@ -3114,6 +3197,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "whoami"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -461,7 +461,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -472,7 +472,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -780,7 +780,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1454,7 +1454,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1559,7 +1559,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1627,7 +1627,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1644,9 +1644,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1849,7 +1849,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallstr",
- "thiserror",
+ "thiserror 1.0.57",
  "time",
  "tokio",
  "tracing",
@@ -1885,7 +1885,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2288,7 +2288,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.57",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2373,7 +2373,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.57",
  "tracing",
  "whoami",
 ]
@@ -2413,7 +2413,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.57",
  "tracing",
  "whoami",
 ]
@@ -2484,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2553,7 +2553,16 @@ version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.57",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+dependencies = [
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -2564,7 +2573,18 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2638,7 +2658,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2727,7 +2747,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2766,7 +2786,7 @@ dependencies = [
  "rand",
  "rustls",
  "sha1",
- "thiserror",
+ "thiserror 1.0.57",
  "url",
  "utf-8",
 ]
@@ -2809,7 +2829,7 @@ checksum = "0b122284365ba8497be951b9a21491f70c9688eb6fddc582931a0703f6a00ece"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2954,7 +2974,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
  "wasm-bindgen-shared",
 ]
 
@@ -2988,7 +3008,7 @@ checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3300,7 +3320,7 @@ dependencies = [
  "either",
  "futures-util",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.57",
 ]
 
 [[package]]
@@ -3323,6 +3343,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serenity",
+ "thiserror 2.0.9",
  "time",
  "youmubot-db",
  "youmubot-db-sql",
@@ -3343,7 +3364,7 @@ dependencies = [
  "poise",
  "reqwest",
  "serenity",
- "thiserror",
+ "thiserror 1.0.57",
  "tokio",
  "youmubot-db",
  "youmubot-db-sql",
@@ -3366,7 +3387,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.93",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,5 @@ members = [
 	"youmubot-osu",
 	"youmubot",
 ]
+[workspace.lints.rust]
+deprecated = "allow"

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
   };
   nixConfig = {
     extra-substituters = [ "https://natsukagami.cachix.org" ];
-    trusted-public-keys = [ "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=" "natsukagami.cachix.org-1:3U6GV8i8gWEaXRUuXd2S4ASfYgdl2QFPWg4BKPbmYiQ=" ];
+    extra-trusted-public-keys = [ "natsukagami.cachix.org-1:3U6GV8i8gWEaXRUuXd2S4ASfYgdl2QFPWg4BKPbmYiQ=" ];
   };
   outputs = { self, nixpkgs, flake-utils, ... }@inputs:
     let

--- a/youmubot-cf/Cargo.toml
+++ b/youmubot-cf/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <natsukagami@gmail.com>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 serde = { version = "1.0.137", features = ["derive"] }

--- a/youmubot-core/Cargo.toml
+++ b/youmubot-core/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <natsukagami@gmail.com>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/youmubot-db-sql/Cargo.toml
+++ b/youmubot-db-sql/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <nki@nkagami.me>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/youmubot-db-sql/migrations/20250220161301_make_last_beatmap_mode_nullable.sql
+++ b/youmubot-db-sql/migrations/20250220161301_make_last_beatmap_mode_nullable.sql
@@ -1,0 +1,6 @@
+-- Add migration script here
+
+ALTER TABLE osu_last_beatmaps RENAME COLUMN mode TO mode_old;
+ALTER TABLE osu_last_beatmaps ADD COLUMN mode INT NULL;
+UPDATE osu_last_beatmaps SET mode = mode_old;
+ALTER TABLE osu_last_beatmaps DROP COLUMN mode_old;

--- a/youmubot-db-sql/src/models/osu.rs
+++ b/youmubot-db-sql/src/models/osu.rs
@@ -3,7 +3,7 @@ use crate::models::*;
 pub struct LastBeatmap {
     pub channel_id: i64,
     pub beatmap: Vec<u8>,
-    pub mode: u8,
+    pub mode: Option<u8>,
 }
 
 impl LastBeatmap {

--- a/youmubot-db/Cargo.toml
+++ b/youmubot-db/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <natsukagami@gmail.com>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/youmubot-osu/Cargo.toml
+++ b/youmubot-osu/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <natsukagami@gmail.com>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/youmubot-osu/Cargo.toml
+++ b/youmubot-osu/Cargo.toml
@@ -24,6 +24,7 @@ poise = "0.6"
 zip = "0.6.2"
 rand = "0.8"
 futures-util = "0.3.30"
+thiserror = "2"
 
 youmubot-db = { path = "../youmubot-db" }
 youmubot-db-sql = { path = "../youmubot-db-sql" }

--- a/youmubot-osu/Cargo.toml
+++ b/youmubot-osu/Cargo.toml
@@ -20,6 +20,7 @@ rosu-map = "0.1"
 time = "0.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serenity = "0.12"
+poise = "0.6"
 zip = "0.6.2"
 rand = "0.8"
 futures-util = "0.3.30"

--- a/youmubot-osu/Cargo.toml
+++ b/youmubot-osu/Cargo.toml
@@ -20,7 +20,7 @@ rosu-map = "0.1"
 time = "0.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serenity = "0.12"
-poise = "0.6"
+poise = { git = "https://github.com/serenity-rs/poise", branch = "current" }
 zip = "0.6.2"
 rand = "0.8"
 futures-util = "0.3.30"

--- a/youmubot-osu/src/discord/announcer.rs
+++ b/youmubot-osu/src/discord/announcer.rs
@@ -337,11 +337,11 @@ impl<'a> CollectedScore<'a> {
                 CreateMessage::new()
                     .content(self.kind.announcement_msg(self.mode, &member))
                     .embed({
-                        let mut b = score_embed(&self.score, bm, content, self.user);
+                        let b = score_embed(&self.score, bm, content, self.user);
                         let b = if let Some(rank) = self.kind.top_record {
                             b.top_record(rank)
                         } else {
-                            &mut b
+                            b
                         };
                         let b = if let Some(rank) = self.kind.world_record {
                             b.world_record(rank)

--- a/youmubot-osu/src/discord/announcer.rs
+++ b/youmubot-osu/src/discord/announcer.rs
@@ -304,7 +304,7 @@ impl<'a> CollectedScore<'a> {
             .get_beatmap_default(self.score.beatmap_id)
             .await?;
         let content = env.oppai.get_beatmap(beatmap.beatmap_id).await?;
-        Ok((BeatmapWithMode(beatmap, self.mode), content))
+        Ok((BeatmapWithMode(beatmap, Some(self.mode)), content))
     }
 
     async fn send_message_to(

--- a/youmubot-osu/src/discord/beatmap_cache.rs
+++ b/youmubot-osu/src/discord/beatmap_cache.rs
@@ -100,7 +100,7 @@ impl BeatmapMetaCache {
     }
 
     /// Get a beatmapset from its ID.
-    pub async fn get_beatmapset(&self, id: u64) -> Result<Vec<Beatmap>> {
+    pub async fn get_beatmapset(&self, id: u64, mode: Option<Mode>) -> Result<Vec<Beatmap>> {
         let bms = models::CachedBeatmap::by_beatmapset(id as i64, &self.pool).await?;
         if !bms.is_empty() {
             return Ok(bms
@@ -110,7 +110,9 @@ impl BeatmapMetaCache {
         }
         let mut beatmaps = self
             .client
-            .beatmaps(crate::BeatmapRequestKind::Beatmapset(id), |f| f)
+            .beatmaps(crate::BeatmapRequestKind::Beatmapset(id), |f| {
+                f.maybe_mode(mode)
+            })
             .await?;
         if beatmaps.is_empty() {
             return Err(Error::msg("beatmapset not found"));

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -1,4 +1,6 @@
 use super::*;
+use poise::CreateReply;
+use serenity::all::User;
 use youmubot_prelude::*;
 
 /// osu!-related command group.
@@ -11,6 +13,93 @@ pub async fn osu<U: HasOsuEnv>(_ctx: CmdContext<'_, U>) -> Result<()> {
 ///
 /// If no osu! username is given, defaults to the currently registered user.
 #[poise::command(slash_command)]
-async fn top<U: HasOsuEnv>(ctx: CmdContext<'_, U>, username: Option<String>) -> Result<()> {
-    todo!()
+async fn top<U: HasOsuEnv>(
+    ctx: CmdContext<'_, U>,
+    #[description = "Index of the score"]
+    #[min = 1]
+    #[max = 100]
+    index: Option<u8>,
+    #[description = "Score listing style"] style: Option<ScoreListStyle>,
+    #[description = "Game mode"] mode: Option<Mode>,
+    #[description = "osu! username"] username: Option<String>,
+    #[description = "Discord username"] user: Option<User>,
+) -> Result<()> {
+    let env = ctx.data().osu_env();
+    let username_arg = match (username, user) {
+        (Some(v), _) => Some(UsernameArg::Raw(v)),
+        (_, Some(u)) => Some(UsernameArg::Tagged(u.id)),
+        (None, None) => None,
+    };
+    let ListingArgs {
+        nth,
+        style,
+        mode,
+        user,
+    } = ListingArgs::from_params(
+        env,
+        index,
+        style.unwrap_or(ScoreListStyle::Table),
+        mode,
+        username_arg,
+        ctx.author().id,
+    )
+    .await?;
+    let osu_client = &env.client;
+
+    ctx.defer().await?;
+
+    let mut plays = osu_client
+        .user_best(UserID::ID(user.id), |f| f.mode(mode).limit(100))
+        .await?;
+
+    plays.sort_unstable_by(|a, b| b.pp.partial_cmp(&a.pp).unwrap());
+    let plays = plays;
+
+    match nth {
+        Nth::Nth(nth) => {
+            let Some(play) = plays.get(nth as usize) else {
+                Err(Error::msg("no such play"))?
+            };
+
+            let beatmap = env.beatmaps.get_beatmap(play.beatmap_id, mode).await?;
+            let content = env.oppai.get_beatmap(beatmap.beatmap_id).await?;
+            let beatmap = BeatmapWithMode(beatmap, mode);
+
+            ctx.send({
+                CreateReply::default()
+                    .content(format!(
+                        "Here is the #{} top play by [`{}`](<{}>)",
+                        nth + 1,
+                        user.username,
+                        user.link()
+                    ))
+                    .embed(
+                        score_embed(&play, &beatmap, &content, user)
+                            .top_record(nth + 1)
+                            .build(),
+                    )
+                    .components(vec![score_components(ctx.guild_id())])
+            })
+            .await?;
+
+            // Save the beatmap...
+            cache::save_beatmap(&env, ctx.channel_id(), &beatmap).await?;
+        }
+        Nth::All => {
+            let reply = ctx
+                .clone()
+                .reply(format!(
+                    "Here are the top plays by [`{}`](<{}>)!",
+                    user.username,
+                    user.link()
+                ))
+                .await?
+                .into_message()
+                .await?;
+            style
+                .display_scores(plays, mode, ctx.serenity_context(), ctx.guild_id(), reply)
+                .await?;
+        }
+    }
+    Ok(())
 }

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -1,0 +1,16 @@
+use super::*;
+use youmubot_prelude::*;
+
+/// osu!-related command group.
+#[poise::command(slash_command, subcommands("top"))]
+pub async fn osu<U: HasOsuEnv>(_ctx: CmdContext<'_, U>) -> Result<()> {
+    Ok(())
+}
+
+/// Returns top plays for a given player.
+///
+/// If no osu! username is given, defaults to the currently registered user.
+#[poise::command(slash_command)]
+async fn top<U: HasOsuEnv>(ctx: CmdContext<'_, U>, username: Option<String>) -> Result<()> {
+    todo!()
+}

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -21,7 +21,8 @@ use serenity::all::User;
         "beatmap",
         "check",
         "ranks",
-        "leaderboard"
+        "leaderboard",
+        "clear_cache"
     )
 )]
 pub async fn osu<U: HasOsuEnv>(_ctx: CmdContext<'_, U>) -> Result<()> {
@@ -639,6 +640,24 @@ async fn leaderboard<U: HasOsuEnv>(
                 .await?;
         }
     }
+    Ok(())
+}
+
+/// Clear youmu's cache.
+#[poise::command(slash_command, owners_only)]
+pub async fn clear_cache<U: HasOsuEnv>(
+    ctx: CmdContext<'_, U>,
+    #[description = "Also clear oppai cache"] clear_oppai: bool,
+) -> Result<()> {
+    let env = ctx.data().osu_env();
+    ctx.defer_ephemeral().await?;
+
+    env.beatmaps.clear().await?;
+
+    if clear_oppai {
+        env.oppai.clear().await?;
+    }
+    ctx.reply("Beatmap cache cleared!").await?;
     Ok(())
 }
 

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -183,15 +183,7 @@ pub async fn save<U: HasOsuEnv>(
         .clone()
         .send(
             CreateReply::default()
-                .content(format!(
-                    "To set your osu username to **{}**, please make your most recent play \
-            be the following map: `/b/{}` in **{}** mode! \
-        It does **not** have to be a pass, and **NF** can be used! \
-        React to this message with 👌 within 5 minutes when you're done!",
-                    u.username,
-                    score.beatmap_id,
-                    mode.as_str_new_site()
-                ))
+                .content(save_request_message(&u.username, score.beatmap_id, mode))
                 .embed(beatmap_embed(&beatmap, mode, Mods::NOMOD, &info))
                 .components(vec![beatmap_components(mode, ctx.guild_id())]),
         )
@@ -349,10 +341,7 @@ async fn beatmap<U: HasOsuEnv>(
             };
             ctx.send(
                 CreateReply::default()
-                    .content(format!(
-                        "Information for beatmap `{}`",
-                        beatmap.short_link(mode, &mods)
-                    ))
+                    .content(format!("Information for {}", beatmap.mention(mode, &mods)))
                     .embed(beatmap_embed(
                         &beatmap,
                         mode.unwrap_or(beatmap.mode),
@@ -372,11 +361,7 @@ async fn beatmap<U: HasOsuEnv>(
             let b0 = &vec[0];
             let msg = ctx
                 .clone()
-                .reply(format!(
-                    "Information for beatmapset [`/s/{}`](<{}>)",
-                    b0.beatmapset_id,
-                    b0.beatmapset_link()
-                ))
+                .reply(format!("Information for {}", b0.beatmapset_mention()))
                 .await?
                 .into_message()
                 .await?;
@@ -475,17 +460,9 @@ async fn check<U: HasOsuEnv>(
     };
 
     let display = if beatmaps.len() == 1 {
-        format!(
-            "[{}](<{}>)",
-            beatmaps[0].0.short_link(None, Mods::NOMOD),
-            beatmaps[0].0.link()
-        )
+        beatmaps[0].0.mention(None, Mods::NOMOD)
     } else {
-        format!(
-            "[/s/{}](<{}>)",
-            beatmaps[0].0.beatmapset_id,
-            beatmaps[0].0.beatmapset_link()
-        )
+        beatmaps[0].0.beatmapset_mention()
     };
 
     let ordering = sort.unwrap_or_default();
@@ -602,10 +579,9 @@ async fn leaderboard<U: HasOsuEnv>(
     let beatmap = &bm.0;
     if scores.is_empty() {
         ctx.reply(format!(
-            "No scores have been recorded in **{}** on [`{}`]({}).",
+            "No scores have been recorded in **{}** on {}.",
             guild.name,
-            beatmap.short_link(mode, Mods::NOMOD),
-            beatmap.link()
+            beatmap.mention(mode, Mods::NOMOD),
         ))
         .await?;
         return Ok(());

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -19,7 +19,8 @@ use serenity::all::User;
         "save",
         "forcesave",
         "beatmap",
-        "check"
+        "check",
+        "ranks"
     )
 )]
 pub async fn osu<U: HasOsuEnv>(_ctx: CmdContext<'_, U>) -> Result<()> {
@@ -519,6 +520,33 @@ async fn check<U: HasOsuEnv>(
         )
         .await?;
 
+    Ok(())
+}
+
+/// Display the rankings of members in the server.
+#[poise::command(slash_command, guild_only)]
+async fn ranks<U: HasOsuEnv>(
+    ctx: CmdContext<'_, U>,
+    #[description = "Sort users by"] sort: Option<server_rank::RankQuery>,
+    #[description = "Reverse the ordering"] reverse: Option<bool>,
+    #[description = "The gamemode for the rankings"] mode: Option<Mode>,
+) -> Result<()> {
+    let env = ctx.data().osu_env();
+    let guild = ctx.partial_guild().await.unwrap();
+    ctx.defer().await?;
+    server_rank::do_server_ranks(
+        ctx.clone().serenity_context(),
+        env,
+        &guild,
+        mode,
+        sort,
+        reverse.unwrap_or(false),
+        |s| async move {
+            let m = ctx.reply(s).await?;
+            Ok(m.into_message().await?)
+        },
+    )
+    .await?;
     Ok(())
 }
 

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -23,7 +23,9 @@ use serenity::all::User;
         "ranks",
         "leaderboard",
         "clear_cache"
-    )
+    ),
+    install_context = "Guild|User",
+    interaction_context = "Guild|BotDm|PrivateChannel"
 )]
 pub async fn osu<U: HasOsuEnv>(_ctx: CmdContext<'_, U>) -> Result<()> {
     Ok(())

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -709,7 +709,10 @@ async fn parse_map_input(
     let output = if beatmapset == Some(true) {
         match output {
             EmbedType::Beatmap(beatmap, _, _) => {
-                let beatmaps = env.beatmaps.get_beatmapset(beatmap.beatmapset_id).await?;
+                let beatmaps = env
+                    .beatmaps
+                    .get_beatmapset(beatmap.beatmapset_id, mode)
+                    .await?;
                 EmbedType::Beatmapset(beatmaps)
             }
             bm @ EmbedType::Beatmapset(_) => bm,

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -519,6 +519,7 @@ async fn ranks<U: HasOsuEnv>(
 async fn leaderboard<U: HasOsuEnv>(
     ctx: CmdContext<'_, U>,
     #[description = "The link or shortlink of the map"] map: Option<String>,
+    #[description = "Load the scoreboard for the entire beatmapset"] beatmapset: Option<bool>,
     #[description = "Sort scores by"] sort: Option<server_rank::OrderBy>,
     #[description = "Reverse the ordering"] reverse: Option<bool>,
     #[description = "Include unranked scores"] unranked: Option<bool>,
@@ -530,7 +531,7 @@ async fn leaderboard<U: HasOsuEnv>(
     let style = style.unwrap_or_default();
     let order = sort.unwrap_or_default();
 
-    let embed = parse_map_input(ctx.channel_id(), env, map, mode, None).await?;
+    let embed = parse_map_input(ctx.channel_id(), env, map, mode, beatmapset).await?;
 
     ctx.defer().await?;
 

--- a/youmubot-osu/src/discord/display.rs
+++ b/youmubot-osu/src/discord/display.rs
@@ -194,7 +194,7 @@ mod scores {
             }
         }
 
-        const ITEMS_PER_PAGE: usize = 5;
+        const ITEMS_PER_PAGE: usize = 10;
 
         #[async_trait]
         impl pagination::Paginate for Paginate {

--- a/youmubot-osu/src/discord/display.rs
+++ b/youmubot-osu/src/discord/display.rs
@@ -194,7 +194,7 @@ mod scores {
             }
         }
 
-        const ITEMS_PER_PAGE: usize = 10;
+        const ITEMS_PER_PAGE: usize = 5;
 
         #[async_trait]
         impl pagination::Paginate for Paginate {

--- a/youmubot-osu/src/discord/display.rs
+++ b/youmubot-osu/src/discord/display.rs
@@ -2,16 +2,19 @@ pub use beatmapset::display_beatmapset;
 pub use scores::ScoreListStyle;
 
 mod scores {
+    use poise::ChoiceParameter;
     use serenity::{all::GuildId, model::channel::Message};
 
     use youmubot_prelude::*;
 
     use crate::models::{Mode, Score};
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, ChoiceParameter)]
     /// The style for the scores list to be displayed.
     pub enum ScoreListStyle {
+        #[name = "ASCII Table"]
         Table,
+        #[name = "List of Embeds"]
         Grid,
     }
 
@@ -166,7 +169,11 @@ mod scores {
             }
 
             paginate_with_first_message(
-                Paginate { scores, mode },
+                Paginate {
+                    header: on.content.clone(),
+                    scores,
+                    mode,
+                },
                 ctx,
                 on,
                 std::time::Duration::from_secs(60),
@@ -176,6 +183,7 @@ mod scores {
         }
 
         pub struct Paginate {
+            header: String,
             scores: Vec<Score>,
             mode: Mode,
         }
@@ -311,6 +319,7 @@ mod scores {
                 let score_table = table_formatting(&SCORE_HEADERS, &SCORE_ALIGNS, score_arr);
 
                 let content = serenity::utils::MessageBuilder::new()
+                    .push_line(&self.header)
                     .push_line(score_table)
                     .push_line(format!("Page **{}/{}**", page + 1, self.total_pages()))
                     .push_line("[?] means pp was predicted by oppai-rs.")

--- a/youmubot-osu/src/discord/embeds.rs
+++ b/youmubot-osu/src/discord/embeds.rs
@@ -506,7 +506,9 @@ impl<'a> FakeScore<'a> {
 
     pub fn embed(self, ctx: &Context) -> Result<CreateEmbed> {
         let BeatmapWithMode(b, mode) = self.bm;
-        let info = self.content.get_info_with(*mode, &self.mods);
+        let info = self
+            .content
+            .get_info_with(mode.unwrap_or(b.mode), &self.mods);
         let attrs = match &info.attrs {
             rosu_pp::any::PerformanceAttributes::Osu(osu_performance_attributes) => {
                 osu_performance_attributes
@@ -540,7 +542,7 @@ impl<'a> FakeScore<'a> {
             "".into()
         } else {
             let pp = self.content.get_pp_from(
-                *mode,
+                mode.unwrap_or(b.mode),
                 None,
                 Stats::AccOnly {
                     acc: accuracy,
@@ -594,7 +596,7 @@ impl<'a> FakeScore<'a> {
                 "Map stats",
                 b.difficulty
                     .apply_mods(&self.mods, attrs.stars())
-                    .format_info(*mode, &self.mods, b),
+                    .format_info(mode.unwrap_or(b.mode), &self.mods, b),
                 false,
             )
             .footer(CreateEmbedFooter::new(
@@ -707,7 +709,7 @@ pub(crate) fn user_embed(u: User, ex: UserExtras) -> CreateEmbed {
                         "> {}",
                         map.difficulty
                             .apply_mods(&v.mods, info.attrs.stars())
-                            .format_info(mode, &v.mods, &map)
+                            .format_info(mode.unwrap_or(map.mode), &v.mods, &map)
                             .replace('\n', "\n> ")
                     ))
                     .build(),

--- a/youmubot-osu/src/discord/embeds.rs
+++ b/youmubot-osu/src/discord/embeds.rs
@@ -270,15 +270,15 @@ pub(crate) struct ScoreEmbedBuilder<'a> {
 }
 
 impl<'a> ScoreEmbedBuilder<'a> {
-    pub fn top_record(&mut self, rank: u8) -> &mut Self {
+    pub fn top_record(mut self, rank: u8) -> Self {
         self.top_record = Some(rank);
         self
     }
-    pub fn world_record(&mut self, rank: u16) -> &mut Self {
+    pub fn world_record(mut self, rank: u16) -> Self {
         self.world_record = Some(rank);
         self
     }
-    pub fn footer(&mut self, footer: impl Into<String>) -> &mut Self {
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
         self.footer = Some(match self.footer.take() {
             None => footer.into(),
             Some(pre) => format!("{} | {}", pre, footer.into()),
@@ -306,7 +306,7 @@ pub(crate) fn score_embed<'a>(
 
 impl<'a> ScoreEmbedBuilder<'a> {
     #[allow(clippy::many_single_char_names)]
-    pub fn build(&mut self) -> CreateEmbed {
+    pub fn build(mut self) -> CreateEmbed {
         let mode = self.bm.mode();
         let b = &self.bm.0;
         let s = self.s;

--- a/youmubot-osu/src/discord/hook.rs
+++ b/youmubot-osu/src/discord/hook.rs
@@ -323,7 +323,7 @@ async fn handle_beatmapset<'a, 'b>(
         ctx.clone(),
         beatmaps,
         mode,
-        Mods::default(),
+        None,
         reply_to.guild_id,
         reply,
     )

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -325,7 +325,7 @@ async fn handle_last_req(
             ctx.clone(),
             beatmapset,
             None,
-            mods,
+            None,
             comp.guild_id,
             reply,
         )

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -400,7 +400,7 @@ pub fn handle_lb_button<'a>(
             .create_followup(
                 &ctx,
                 CreateInteractionResponseFollowup::new().content(format!(
-                    "⌛ Loading top scores on beatmap `{}`...",
+                    "Here are the top scores on beatmap `{}`!",
                     bm.short_link(Mods::NOMOD)
                 )),
             )

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -313,12 +313,15 @@ async fn handle_last_req(
     let mods = mods_def.unwrap_or_default();
 
     if is_beatmapset_req {
-        let beatmapset = env.beatmaps.get_beatmapset(bm.0.beatmapset_id).await?;
+        let beatmapset = env
+            .beatmaps
+            .get_beatmapset(bm.0.beatmapset_id, None)
+            .await?;
         let reply = comp
             .create_followup(
                 &ctx,
                 CreateInteractionResponseFollowup::new()
-                    .content(format!("Beatmapset of `{}`", bm.short_link(&mods))),
+                    .content(format!("Beatmapset `{}`", bm.0.beatmapset_mention())),
             )
             .await?;
         super::display::display_beatmapset(

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -79,7 +79,7 @@ pub fn handle_check_button<'a>(
         };
         let header = UserHeader::from(user.clone());
 
-        let scores = super::do_check(&env, &bm, Mods::NOMOD, &header).await?;
+        let scores = super::do_check(&env, &vec![bm.clone()], None, &header).await?;
         if scores.is_empty() {
             comp.create_followup(
                 &ctx,

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -675,7 +675,7 @@ pub async fn recent(ctx: &Context, msg: &Message, mut args: Args) -> CommandResu
             let reply = msg
                 .reply(
                     ctx,
-                    format!("Here are the recent plays by `{}`!", user.username),
+                    format!("Here are the recent plays by {}!", user.mention()),
                 )
                 .await?;
             style
@@ -699,7 +699,11 @@ pub async fn recent(ctx: &Context, msg: &Message, mut args: Args) -> CommandResu
                 .send_message(
                     &ctx,
                     CreateMessage::new()
-                        .content("Here is the play that you requested".to_string())
+                        .content(format!(
+                            "Here is the #{} recent play by {}!",
+                            nth + 1,
+                            user.mention()
+                        ))
                         .embed(
                             score_embed(play, &beatmap_mode, &content, user)
                                 .footer(format!("Attempt #{}", attempts))
@@ -1007,7 +1011,7 @@ pub async fn top(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult 
                 .send_message(&ctx, {
                     CreateMessage::new()
                         .content(format!(
-                            "Here is the #{} top play by {}",
+                            "Here is the #{} top play by {}!",
                             nth + 1,
                             user.mention()
                         ))

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -859,10 +859,7 @@ pub async fn last(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
 
     match b {
         Some((bm, mods_def)) => {
-            let mods = match args.find::<UnparsedMods>().ok() {
-                Some(m) => m.to_mods(bm.mode())?,
-                None => mods_def.unwrap_or_default(),
-            };
+            let mods = args.find::<UnparsedMods>().ok();
             if beatmapset {
                 let beatmapset = env.beatmaps.get_beatmapset(bm.0.beatmapset_id).await?;
                 let reply = msg
@@ -879,6 +876,10 @@ pub async fn last(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
                 .await?;
                 return Ok(());
             }
+            let mods = match mods {
+                Some(m) => m.to_mods(bm.mode())?,
+                None => mods_def.unwrap_or_default(),
+            };
             let info = env
                 .oppai
                 .get_beatmap(bm.0.beatmap_id)

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -257,21 +257,25 @@ pub async fn save(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
         .send_message(
             &ctx,
             CreateMessage::new()
-                .content(format!(
-                    "To set your osu username to **{}**, please make your most recent play \
-            be the following map: `/b/{}` in **{}** mode! \
-        It does **not** have to be a pass, and **NF** can be used! \
-        React to this message with 👌 within 5 minutes when you're done!",
-                    u.username,
-                    score.beatmap_id,
-                    mode.as_str_new_site()
-                ))
+                .content(save_request_message(&u.username, score.beatmap_id, mode))
                 .embed(beatmap_embed(&beatmap, mode, Mods::NOMOD, &info))
                 .components(vec![beatmap_components(mode, msg.guild_id)]),
         )
         .await?;
     handle_save_respond(ctx, &env, msg.author.id, reply, &beatmap, u, mode).await?;
     Ok(())
+}
+
+pub(crate) fn save_request_message(username: &str, beatmap_id: u64, mode: Mode) -> String {
+    format!(
+        "To set your osu username to **{}**, please make your most recent play \
+            be the following map: `/b/{}` in **{}** mode! \
+        It does **not** have to be a pass, and **NF** can be used! \
+        React to this message with 👌 within 5 minutes when you're done!",
+        username,
+        beatmap_id,
+        mode.as_str_new_site()
+    )
 }
 
 pub(crate) async fn find_save_requirements(
@@ -943,9 +947,9 @@ pub async fn check(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
         .reply(
             &ctx,
             format!(
-                "Here are the scores by `{}` on `{}`!",
+                "Here are the scores by `{}` on {}!",
                 &user.username,
-                bm.short_link(&mods)
+                bm.0.mention(Some(bm.1), &mods)
             ),
         )
         .await?;

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -15,6 +15,7 @@ use serenity::{
     utils::MessageBuilder,
 };
 
+pub use commands::osu as osu_command;
 use db::{OsuLastBeatmap, OsuSavedUsers, OsuUser, OsuUserMode};
 use embeds::{beatmap_embed, score_embed, user_embed};
 pub use hook::{dot_osu_hook, hook, score_hook};
@@ -38,6 +39,7 @@ use crate::{
 mod announcer;
 pub(crate) mod beatmap_cache;
 mod cache;
+mod commands;
 mod db;
 pub(crate) mod display;
 pub(crate) mod embeds;
@@ -65,6 +67,17 @@ pub struct OsuEnv {
     pub(crate) client: Arc<crate::OsuClient>,
     pub(crate) oppai: BeatmapCache,
     pub(crate) beatmaps: BeatmapMetaCache,
+}
+
+/// Gets an [OsuEnv] from the current environment.
+pub trait HasOsuEnv: Send + Sync {
+    fn osu_env(&self) -> &OsuEnv;
+}
+
+impl<T: AsRef<OsuEnv> + Send + Sync> HasOsuEnv for T {
+    fn osu_env(&self) -> &OsuEnv {
+        self.as_ref()
+    }
 }
 
 impl std::fmt::Debug for OsuEnv {

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -865,7 +865,13 @@ pub async fn last(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
         Some((bm, mods_def)) => {
             let mods = args.find::<UnparsedMods>().ok();
             if beatmapset {
-                let beatmapset = env.beatmaps.get_beatmapset(bm.0.beatmapset_id).await?;
+                let beatmapset = env
+                    .beatmaps
+                    .get_beatmapset(
+                        bm.0.beatmapset_id,
+                        None, /* Note that we cannot know, so don't force that */
+                    )
+                    .await?;
                 let reply = msg
                     .reply(&ctx, "Here is the beatmapset you requested!")
                     .await?;

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -1007,10 +1007,9 @@ pub async fn top(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult 
                 .send_message(&ctx, {
                     CreateMessage::new()
                         .content(format!(
-                            "Here is the #{} top play by [`{}`](<{}>)",
+                            "Here is the #{} top play by {}",
                             nth + 1,
-                            user.username,
-                            user.link()
+                            user.mention()
                         ))
                         .embed(
                             score_embed(&play, &beatmap, &content, user)
@@ -1028,11 +1027,7 @@ pub async fn top(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult 
             let reply = msg
                 .reply(
                     &ctx,
-                    format!(
-                        "Here are the top plays by [`{}`](<{}>)!",
-                        user.username,
-                        user.link()
-                    ),
+                    format!("Here are the top plays by {}!", user.mention()),
                 )
                 .await?;
             style
@@ -1080,10 +1075,7 @@ async fn get_user(
                 .send_message(
                     &ctx,
                     CreateMessage::new()
-                        .content(format!(
-                            "{}: here is the user that you requested",
-                            msg.author
-                        ))
+                        .content(format!("Here is {}'s **{}** profile!", u.mention(), mode))
                         .embed(user_embed(u, ex)),
                 )
                 .await?;

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -333,7 +333,7 @@ pub(crate) async fn handle_save_respond(
     mode: Mode,
 ) -> Result<()> {
     let osu_client = &env.client;
-    async fn check(client: &OsuHttpClient, u: &User, map_id: u64) -> Result<bool> {
+    async fn check(client: &OsuHttpClient, u: &User, mode: Mode, map_id: u64) -> Result<bool> {
         Ok(client
             .user_recent(UserID::ID(u.id), |f| f.mode(Mode::Std).limit(1))
             .await?
@@ -352,7 +352,7 @@ pub(crate) async fn handle_save_respond(
             .next()
             .await;
         if let Some(ur) = user_reaction {
-            if check(osu_client, &user, beatmap.beatmap_id).await? {
+            if check(osu_client, &user, mode, beatmap.beatmap_id).await? {
                 break true;
             }
             ur.delete(&ctx).await?;

--- a/youmubot-osu/src/discord/server_rank.rs
+++ b/youmubot-osu/src/discord/server_rank.rs
@@ -548,6 +548,7 @@ pub async fn display_rankings_table(
     const ITEMS_PER_PAGE: usize = 5;
     let total_len = scores.len();
     let total_pages = (total_len + ITEMS_PER_PAGE - 1) / ITEMS_PER_PAGE;
+    let header = Arc::new(to.content.clone());
 
     paginate_with_first_message(
         paginate_from_fn(move |page: u8, ctx: &Context, m: &mut Message| {
@@ -558,6 +559,7 @@ pub async fn display_rankings_table(
             }
             let scores = scores[start..end].to_vec();
             let bm = (bm.0.clone(), bm.1);
+            let header = header.clone();
             Box::pin(async move {
                 const SCORE_HEADERS: [&str; 8] =
                     ["#", "Score", "Mods", "Rank", "Acc", "Combo", "Miss", "User"];
@@ -608,6 +610,7 @@ pub async fn display_rankings_table(
                     OrderBy::Score => table_formatting(&SCORE_HEADERS, &ALIGNS, score_arr),
                 };
                 let content = MessageBuilder::new()
+                    .push_line(header.as_ref())
                     .push_line(score_table)
                     .push_line(format!(
                         "Page **{}**/**{}**. Not seeing your scores? Run `osu check` to update.",

--- a/youmubot-osu/src/discord/server_rank.rs
+++ b/youmubot-osu/src/discord/server_rank.rs
@@ -328,7 +328,7 @@ where
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, poise::ChoiceParameter)]
 pub enum OrderBy {
     PP,
     Score,
@@ -376,14 +376,12 @@ pub async fn show_leaderboard(ctx: &Context, msg: &Message, mut args: Args) -> C
     let style = args.single::<ScoreListStyle>().unwrap_or_default();
     let guild = msg.guild_id.expect("Guild-only command");
     let env = ctx.data.read().await.get::<OsuEnv>().unwrap().clone();
-    let bm = match super::load_beatmap(&env, msg.channel_id, msg.referenced_message.as_ref()).await
-    {
-        Some((bm, _)) => bm,
-        None => {
-            msg.reply(&ctx, "No beatmap queried on this channel.")
-                .await?;
-            return Ok(());
-        }
+    let Some((bm, _)) =
+        super::load_beatmap(&env, msg.channel_id, msg.referenced_message.as_ref()).await
+    else {
+        msg.reply(&ctx, "No beatmap queried on this channel.")
+            .await?;
+        return Ok(());
     };
 
     let scores = {

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -341,6 +341,14 @@ impl Mode {
             Mode::Mania => "mania",
         }
     }
+
+    pub fn with_override(self, opt_mode: impl Into<Option<Mode>>) -> Self {
+        if self == Mode::Std {
+            opt_mode.into().unwrap_or(self)
+        } else {
+            self
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -10,6 +10,7 @@ pub mod mods;
 pub(crate) mod rosu;
 
 pub use mods::Mods;
+use poise::ChoiceParameter;
 use serenity::utils::MessageBuilder;
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
@@ -266,11 +267,17 @@ impl fmt::Display for Language {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, std::hash::Hash)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, std::hash::Hash, ChoiceParameter,
+)]
 pub enum Mode {
+    #[name = "osu!"]
     Std,
+    #[name = "osu!taiko"]
     Taiko,
+    #[name = "osu!catch"]
     Catch,
+    #[name = "osu!mania"]
     Mania,
 }
 

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -3,7 +3,7 @@ use mods::Stats;
 use rosu_v2::prelude::{GameModIntermode, ScoreStatistics};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::fmt;
+use std::fmt::{self, Display};
 use std::time::Duration;
 
 pub mod mods;
@@ -561,6 +561,10 @@ pub struct User {
 }
 
 impl User {
+    pub fn mention<'a>(&'a self) -> impl Display + 'a {
+        UserHeaderLink(&self.username, self.id)
+    }
+
     pub fn link(&self) -> String {
         format!("https://osu.ppy.sh/users/{}", self.id)
     }
@@ -570,7 +574,20 @@ impl User {
     }
 }
 
+#[derive(Debug, Clone)]
+struct UserHeaderLink<'a>(&'a String, u64);
+
+impl<'a> Display for UserHeaderLink<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}](<https://osu.ppy.sh/users/{}>)", self.0, self.1)
+    }
+}
+
 impl UserHeader {
+    pub fn mention<'a>(&'a self) -> impl Display + 'a {
+        UserHeaderLink(&self.username, self.id)
+    }
+
     pub fn link(&self) -> String {
         format!("https://osu.ppy.sh/users/{}", self.id)
     }

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -452,7 +452,7 @@ impl Beatmap {
 
     pub fn mention(&self, override_mode: Option<Mode>, mods: &Mods) -> String {
         format!(
-            "[`{}`]({})",
+            "[`{}`](<{}>)",
             self.short_link(override_mode, mods),
             self.mode_link(override_mode),
         )

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -414,9 +414,16 @@ impl Beatmap {
 
     /// Gets a link pointing to the beatmap, in the new format.
     pub fn link(&self) -> String {
+        self.mode_link(None)
+    }
+
+    /// Gets a link pointing to the beatmap, in the new format, with overridable mode.
+    pub fn mode_link(&self, mode: Option<Mode>) -> String {
         format!(
             "https://osu.ppy.sh/beatmapsets/{}#{}/{}",
-            self.beatmapset_id, NEW_MODE_NAMES[self.mode as usize], self.beatmap_id
+            self.beatmapset_id,
+            NEW_MODE_NAMES[self.mode.with_override(mode) as usize],
+            self.beatmap_id
         )
     }
 
@@ -440,6 +447,14 @@ impl Beatmap {
                 _ => "".to_owned(),
             },
             mods
+        )
+    }
+
+    pub fn mention(&self, override_mode: Option<Mode>, mods: &Mods) -> String {
+        format!(
+            "[`{}`]({})",
+            self.short_link(override_mode, mods),
+            self.mode_link(override_mode),
         )
     }
 

--- a/youmubot-osu/src/models/mod.rs
+++ b/youmubot-osu/src/models/mod.rs
@@ -457,6 +457,9 @@ impl Beatmap {
             self.mode_link(override_mode),
         )
     }
+    pub fn beatmapset_mention(&self) -> String {
+        format!("[/s/{}](<{}>)", self.beatmapset_id, self.beatmapset_link())
+    }
 
     /// Link to the cover image of the beatmap.
     pub fn cover_url(&self) -> String {

--- a/youmubot-prelude/Cargo.toml
+++ b/youmubot-prelude/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <natsukagami@gmail.com>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/youmubot-prelude/Cargo.toml
+++ b/youmubot-prelude/Cargo.toml
@@ -18,7 +18,7 @@ chrono = "0.4.19"
 flume = "0.10.13"
 dashmap = "5.3.4"
 thiserror = "1"
-poise = "0.6"
+poise = { git = "https://github.com/serenity-rs/poise", branch = "current" }
 
 [dependencies.serenity]
 version = "0.12"

--- a/youmubot/Cargo.toml
+++ b/youmubot/Cargo.toml
@@ -13,7 +13,7 @@ codeforces = ["youmubot-cf"]
 
 [dependencies]
 serenity = "0.12"
-poise = "0.6"
+poise = { git = "https://github.com/serenity-rs/poise", branch = "current" }
 tokio = { version = "1.19.2", features = ["rt-multi-thread"] }
 dotenv = "0.15.0"
 env_logger = "0.9.0"

--- a/youmubot/Cargo.toml
+++ b/youmubot/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Natsu Kagami <natsukagami@gmail.com>"]
 edition = "2021"
 
+[lints]
+workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = ["core", "codeforces", "osu"]

--- a/youmubot/src/main.rs
+++ b/youmubot/src/main.rs
@@ -61,6 +61,7 @@ impl AsRef<youmubot_prelude::Env> for Env {
     }
 }
 
+#[cfg(feature = "osu")]
 impl AsRef<youmubot_osu::discord::OsuEnv> for Env {
     fn as_ref(&self) -> &youmubot_osu::discord::OsuEnv {
         &self.osu
@@ -257,7 +258,11 @@ async fn main() {
                     }
                 })
             },
-            commands: vec![poise_register()],
+            commands: vec![
+                poise_register(),
+                #[cfg(feature = "osu")]
+                youmubot_osu::discord::osu_command(),
+            ],
             ..Default::default()
         })
         .build();

--- a/youmubot/src/main.rs
+++ b/youmubot/src/main.rs
@@ -247,12 +247,14 @@ async fn main() {
                 Box::pin(async move {
                     if let poise::FrameworkError::Command { error, ctx, .. } = err {
                         let reply = format!(
-                            "Command '{}' returned error {:?}",
+                            "Command '{}' returned error: {:?}",
                             ctx.invoked_command_name(),
                             error
                         );
-                        ctx.reply(&reply).await.pls_ok();
-                        println!("{}", reply)
+                        println!("{}", reply);
+                        ctx.send(poise::CreateReply::default().content(reply).ephemeral(true))
+                            .await
+                            .pls_ok();
                     } else {
                         eprintln!("Poise error: {:?}", err)
                     }


### PR DESCRIPTION
Implemented commands:
- `top`
- `profile`
- `recent`
- `save`
- `forcesave`
- `pinned`
- `beatmap`
- `check`
- `ranks`
- `leaderboard`
- `clear_cache`

Messy code needs to be cleaned up (especially where `.mention()` can be used on beatmaps)
