### PR TITLE
Migrate from crane back to buildRustPackage

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -64,6 +64,16 @@ jobs:
               run: cargo test
               env:
                   SQLX_OFFLINE: "true"
+    checkDeps:
+        name: Check dependency hash
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: cachix/install-nix-action@v27
+              with:
+                github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Build dependencies
+              run: nix build .#youmubot.cargoDeps --option substituters "https://cache.nixos.org" --option extra-substituters ""
     build:
         name: Build
         runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "locked": {
-        "lastModified": 1734744351,
-        "narHash": "sha256-fN9npuZHHHzDVr1wuKoh/TheHkerDaLB9l4vj/48Exg=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "a83a48a62640517588c3d137c948ed034706363c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -51,7 +36,6 @@
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
             };
         in
         rec {
-          packages.youmubot = pkgs.callPackage ./package.nix {};
+          packages.youmubot = pkgs.callPackage ./package.nix { };
 
           defaultPackage = packages.youmubot;
 
@@ -48,7 +48,7 @@
             };
         }) // {
       overlays.default = final: prev: {
-        youmubot = final.callPackage ./package.nix {};
+        youmubot = final.callPackage ./package.nix { };
       };
       # module
       nixosModules.default = import ./module.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "A discord bot for Dự Tuyển Tổng Hợp server";
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    crane.url = "github:ipetkov/crane";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
@@ -14,9 +13,6 @@
     extra-trusted-public-keys = [ "natsukagami.cachix.org-1:3U6GV8i8gWEaXRUuXd2S4ASfYgdl2QFPWg4BKPbmYiQ=" ];
   };
   outputs = { self, nixpkgs, flake-utils, ... }@inputs:
-    let
-      rustVersion = "1.83.0";
-    in
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -24,11 +20,9 @@
             {
               inherit system; overlays = [ (import inputs.rust-overlay) ];
             };
-          craneLib = (inputs.crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.${rustVersion}.default);
-          # craneLib = inputs.crane.mkLib pkgs;
         in
         rec {
-          packages.youmubot = pkgs.callPackage ./package.nix { inherit craneLib; };
+          packages.youmubot = pkgs.callPackage ./package.nix {};
 
           defaultPackage = packages.youmubot;
 
@@ -54,9 +48,7 @@
             };
         }) // {
       overlays.default = final: prev: {
-        youmubot = final.callPackage ./package.nix {
-          craneLib = (inputs.crane.mkLib final).overrideToolchain (p: p.rust-bin.stable.${rustVersion}.default);
-        };
+        youmubot = final.callPackage ./package.nix {};
       };
       # module
       nixosModules.default = import ./module.nix;

--- a/package.nix
+++ b/package.nix
@@ -1,27 +1,41 @@
-{ craneLib
+{ pkgs
 , lib
 , stdenv
 , pkg-config
 , openssl
 
-, enableCodeforces ? true
+, enableCodeforces ? false
 , enableOsu ? true
 , ...
 }:
 let
   customizeFeatures = !(enableCodeforces && enableOsu);
-  featureFlags = lib.optionals customizeFeatures (
-    [ "--no-default-features" "--features=core" ]
-    ++ lib.optional enableCodeforces "--features=codeforces"
-    ++ lib.optional enableOsu "--features=osu"
-  );
 in
-craneLib.buildPackage {
+pkgs.rustPlatform.buildRustPackage {
   pname = "youmubot";
   version = "0.1.0";
 
   src = ./.;
-  cargoExtraArgs = builtins.concatStringsSep " " ([ "--locked" "--package youmubot" ] ++ featureFlags);
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    outputHashes = {
+      "poise-0.6.1" = "sha256-44pPe02JJ97GEpzAXdQmDq/9bb4KS9G7ZFVlBRC6EYs=";
+      "rosu-v2-0.9.0" = "sha256-dx0EwqqgkLaHwCPHyn5vMkhZ2NZcahH5SACFcsJKP1E=";
+    };
+  };
+
+  buildNoDefaultFeatures = customizeFeatures;
+  buildFeatures = lib.optionals customizeFeatures (
+    [ "core" ]
+    ++ lib.optional enableCodeforces "codeforces"
+    ++ lib.optional enableOsu "osu"
+  );
+
+  cargoBuildFlags = [
+    "--locked"
+    "--package"
+    "youmubot"
+  ];
 
   buildInputs = [
     openssl
@@ -33,4 +47,3 @@ craneLib.buildPackage {
 
   SQLX_OFFLINE = "true";
 }
-

--- a/package.nix
+++ b/package.nix
@@ -1,4 +1,4 @@
-{ pkgs
+{ rustPlatform
 , lib
 , stdenv
 , pkg-config
@@ -11,7 +11,7 @@
 let
   customizeFeatures = !(enableCodeforces && enableOsu);
 in
-pkgs.rustPlatform.buildRustPackage {
+rustPlatform.buildRustPackage {
   pname = "youmubot";
   version = "0.1.0";
 


### PR DESCRIPTION
Remove crane library, and use buildRustPackage for the package. This also means removing the rust version from flake.nix, and now hashes of git packages have to be specified.

Added a new CI job for building only the dependencies, using only the default binary cache.

Additionally, the enableCodeforces module is now disabled by default.