### PR TITLE
Implement lazy score queries for `top`, `recent` and `check`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+dotenv
 use flake

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -3905,6 +3906,7 @@ dependencies = [
  "bitflags 1.3.2",
  "chrono",
  "dashmap 5.5.3",
+ "futures",
  "futures-util",
  "lazy_static",
  "poise",

--- a/youmubot-osu/Cargo.toml
+++ b/youmubot-osu/Cargo.toml
@@ -26,7 +26,8 @@ serenity = "0.12"
 poise = { git = "https://github.com/serenity-rs/poise", branch = "current" }
 zip = "0.6.2"
 rand = "0.8"
-futures-util = "0.3.30"
+futures = "0.3"
+futures-util = "0.3"
 thiserror = "2"
 
 youmubot-db = { path = "../youmubot-db" }

--- a/youmubot-osu/src/discord/announcer.rs
+++ b/youmubot-osu/src/discord/announcer.rs
@@ -212,7 +212,8 @@ impl Announcer {
         };
         let top_scores = env
             .client
-            .user_best(user_id.clone(), |f| f.mode(mode).limit(100));
+            .user_best(user_id.clone(), |f| f.mode(mode))
+            .try_collect::<Vec<_>>();
         let (user, top_scores) = try_join!(user, top_scores)?;
         let mut user = user.unwrap();
         // if top scores exist, user would too

--- a/youmubot-osu/src/discord/announcer.rs
+++ b/youmubot-osu/src/discord/announcer.rs
@@ -22,6 +22,7 @@ use youmubot_prelude::*;
 
 use crate::discord::calculate_weighted_map_age;
 use crate::discord::db::OsuUserMode;
+use crate::scores::Scores;
 use crate::{
     discord::cache::save_beatmap,
     discord::oppai_cache::BeatmapContent,
@@ -212,8 +213,8 @@ impl Announcer {
         };
         let top_scores = env
             .client
-            .user_best(user_id.clone(), |f| f.mode(mode))
-            .try_collect::<Vec<_>>();
+            .user_best(user_id.clone(), move |f| f.mode(mode))
+            .and_then(|v| v.get_all());
         let (user, top_scores) = try_join!(user, top_scores)?;
         let mut user = user.unwrap();
         // if top scores exist, user would too
@@ -264,14 +265,14 @@ impl<'a> CollectedScore<'a> {
         user: &'a User,
         event: UserEventRank,
     ) -> Result<CollectedScore<'a>> {
-        let scores = osu
+        let mut scores = osu
             .scores(event.beatmap_id, |f| {
                 f.user(UserID::ID(user.id)).mode(event.mode)
             })
             .await?;
         let score = match scores
-            .into_iter()
             .find(|s| (s.date - event.date).abs() < chrono::TimeDelta::seconds(5))
+            .await?
         {
             Some(v) => v,
             None => {
@@ -283,7 +284,7 @@ impl<'a> CollectedScore<'a> {
         };
         Ok(Self {
             user,
-            score,
+            score: score.clone(),
             mode: event.mode,
             kind: ScoreType::world(event.rank),
         })

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -303,20 +303,14 @@ async fn handle_listing<U: HasOsuEnv>(
             cache::save_beatmap(&env, ctx.channel_id(), &beatmap).await?;
         }
         Nth::All => {
-            let reply = ctx
-                .clone()
-                .reply(format!(
-                    "Here are the {} plays by {}!",
-                    listing_kind,
-                    user.mention()
-                ))
-                .await?;
+            let header = format!("Here are the {} plays by {}!", listing_kind, user.mention());
+            let reply = ctx.clone().reply(&header).await?;
             style
                 .display_scores(
                     plays.try_collect::<Vec<_>>().await?,
                     ctx.clone().serenity_context(),
                     ctx.guild_id(),
-                    (reply, ctx),
+                    (reply, ctx).with_header(header),
                 )
                 .await?;
         }
@@ -480,14 +474,12 @@ async fn check<U: HasOsuEnv>(
         scores.reverse();
     }
 
-    let msg = ctx
-        .clone()
-        .reply(format!(
-            "Here are the plays by {} on {}!",
-            args.user.mention(),
-            display
-        ))
-        .await?;
+    let header = format!(
+        "Here are the plays by {} on {}!",
+        args.user.mention(),
+        display
+    );
+    let msg = ctx.clone().reply(&header).await?;
 
     let style = style.unwrap_or(if scores.len() <= 5 {
         ScoreListStyle::Grid
@@ -500,7 +492,7 @@ async fn check<U: HasOsuEnv>(
             scores,
             ctx.clone().serenity_context(),
             ctx.guild_id(),
-            (msg, ctx),
+            (msg, ctx).with_header(header),
         )
         .await?;
 

--- a/youmubot-osu/src/discord/commands.rs
+++ b/youmubot-osu/src/discord/commands.rs
@@ -307,7 +307,7 @@ async fn handle_listing<U: HasOsuEnv>(
             let reply = ctx.clone().reply(&header).await?;
             style
                 .display_scores(
-                    plays.try_collect::<Vec<_>>().await?,
+                    plays.try_collect::<Vec<_>>(),
                     ctx.clone().serenity_context(),
                     ctx.guild_id(),
                     (reply, ctx).with_header(header),
@@ -489,7 +489,7 @@ async fn check<U: HasOsuEnv>(
 
     style
         .display_scores(
-            scores,
+            future::ok(scores),
             ctx.clone().serenity_context(),
             ctx.guild_id(),
             (msg, ctx).with_header(header),
@@ -612,7 +612,7 @@ async fn leaderboard<U: HasOsuEnv>(
             let reply = ctx.reply(header).await?;
             style
                 .display_scores(
-                    scores.into_iter().map(|s| s.score).collect(),
+                    future::ok(scores.into_iter().map(|s| s.score).collect()),
                     ctx.serenity_context(),
                     Some(guild.id),
                     (reply, ctx),

--- a/youmubot-osu/src/discord/display.rs
+++ b/youmubot-osu/src/discord/display.rs
@@ -2,14 +2,12 @@ pub use beatmapset::display_beatmapset;
 pub use scores::ScoreListStyle;
 
 mod scores {
-    use std::future::Future;
-
     use poise::ChoiceParameter;
     use serenity::all::GuildId;
 
     use youmubot_prelude::*;
 
-    use crate::models::Score;
+    use crate::scores::Scores;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq, ChoiceParameter)]
     /// The style for the scores list to be displayed.
@@ -43,7 +41,7 @@ mod scores {
     impl ScoreListStyle {
         pub async fn display_scores(
             self,
-            scores: impl Future<Output = Result<Vec<Score>>>,
+            scores: impl Scores,
             ctx: &Context,
             guild_id: Option<GuildId>,
             m: impl CanEdit,
@@ -57,8 +55,6 @@ mod scores {
     }
 
     mod grid {
-        use std::future::Future;
-
         use pagination::paginate_with_first_message;
         use serenity::all::{CreateActionRow, GuildId};
 
@@ -66,17 +62,16 @@ mod scores {
 
         use crate::discord::interaction::score_components;
         use crate::discord::{cache::save_beatmap, BeatmapWithMode, OsuEnv};
-        use crate::models::Score;
+        use crate::scores::Scores;
 
         pub async fn display_scores_grid(
-            scores: impl Future<Output = Result<Vec<Score>>>,
+            scores: impl Scores,
             ctx: &Context,
             guild_id: Option<GuildId>,
             mut on: impl CanEdit,
         ) -> Result<()> {
             let env = ctx.data.read().await.get::<OsuEnv>().unwrap().clone();
             let channel_id = on.get_message().await?.channel_id;
-            let scores = scores.await?;
             if scores.is_empty() {
                 on.apply_edit(CreateReply::default().content("No plays found"))
                     .await?;
@@ -98,15 +93,22 @@ mod scores {
             Ok(())
         }
 
-        pub struct Paginate {
+        pub struct Paginate<T: Scores> {
             env: OsuEnv,
-            scores: Vec<Score>,
+            scores: T,
             guild_id: Option<GuildId>,
             channel_id: serenity::all::ChannelId,
         }
 
+        impl<T: Scores> Paginate<T> {
+            fn pages_fake(&self) -> usize {
+                let size = self.scores.length_fetched();
+                size.count() + if size.is_total() { 0 } else { 1 }
+            }
+        }
+
         #[async_trait]
-        impl pagination::Paginate for Paginate {
+        impl<T: Scores> pagination::Paginate for Paginate<T> {
             async fn render(
                 &mut self,
                 page: u8,
@@ -114,7 +116,10 @@ mod scores {
             ) -> Result<Option<CreateReply>> {
                 let env = &self.env;
                 let page = page as usize;
-                let score = &self.scores[page];
+                let Some(score) = self.scores.get(page).await? else {
+                    return Ok(None);
+                };
+                let score = score.clone();
 
                 let beatmap = env
                     .beatmaps
@@ -137,8 +142,12 @@ mod scores {
                 Ok(Some(
                     CreateReply::default()
                         .embed({
-                            crate::discord::embeds::score_embed(score, &bm, &content, &user)
-                                .footer(format!("Page {}/{}", page + 1, self.scores.len()))
+                            crate::discord::embeds::score_embed(&score, &bm, &content, &user)
+                                .footer(format!(
+                                    "Page {} / {}",
+                                    page + 1,
+                                    self.scores.length_fetched()
+                                ))
                                 .build()
                         })
                         .components(
@@ -151,14 +160,13 @@ mod scores {
             }
 
             fn len(&self) -> Option<usize> {
-                Some(self.scores.len())
+                Some(self.pages_fake())
             }
         }
     }
 
     pub mod table {
         use std::borrow::Cow;
-        use std::future::Future;
 
         use pagination::paginate_with_first_message;
         use serenity::all::{CreateActionRow, CreateAttachment};
@@ -169,29 +177,28 @@ mod scores {
 
         use crate::discord::oppai_cache::Stats;
         use crate::discord::{time_before_now, Beatmap, BeatmapInfo, OsuEnv};
-        use crate::models::Score;
+        use crate::scores::Scores;
 
         pub async fn display_scores_as_file(
-            scores: impl Future<Output = Result<Vec<Score>>>,
+            scores: impl Scores,
             ctx: &Context,
             mut on: impl CanEdit,
         ) -> Result<()> {
             let header = on.headers().unwrap_or("").to_owned();
             let content = format!("{}\n\nPreparing file...", header);
-            let preparing = on.apply_edit(CreateReply::default().content(content));
-            let (_, scores) = future::try_join(preparing, scores).await?;
-            if scores.is_empty() {
-                on.apply_edit(CreateReply::default().content("No plays found"))
-                    .await?;
-                return Ok(());
-            }
+            on.apply_edit(CreateReply::default().content(content))
+                .await?;
 
-            let p = Paginate {
+            let mut p = Paginate {
                 env: ctx.data.read().await.get::<OsuEnv>().unwrap().clone(),
                 header: header.clone(),
                 scores,
             };
-            let content = p.to_table(0, p.scores.len()).await;
+            let Some(content) = p.to_table(0, usize::max_value()).await? else {
+                on.apply_edit(CreateReply::default().content("No plays found"))
+                    .await?;
+                return Ok(());
+            };
             on.apply_edit(
                 CreateReply::default()
                     .content(header)
@@ -202,11 +209,10 @@ mod scores {
         }
 
         pub async fn display_scores_table(
-            scores: impl Future<Output = Result<Vec<Score>>>,
+            scores: impl Scores,
             ctx: &Context,
             mut on: impl CanEdit,
         ) -> Result<()> {
-            let scores = scores.await?;
             if scores.is_empty() {
                 on.apply_edit(CreateReply::default().content("No plays found"))
                     .await?;
@@ -227,19 +233,18 @@ mod scores {
             Ok(())
         }
 
-        pub struct Paginate {
+        pub struct Paginate<T: Scores> {
             env: OsuEnv,
             header: String,
-            scores: Vec<Score>,
+            scores: T,
         }
 
-        impl Paginate {
-            fn total_pages(&self) -> usize {
-                (self.scores.len() + ITEMS_PER_PAGE - 1) / ITEMS_PER_PAGE
-            }
-
-            async fn to_table(&self, start: usize, end: usize) -> String {
-                let scores = &self.scores[start..end];
+        impl<T: Scores> Paginate<T> {
+            async fn to_table(&mut self, start: usize, end: usize) -> Result<Option<String>> {
+                let scores = self.scores.get_range(start..end).await?;
+                if scores.is_empty() {
+                    return Ok(None);
+                }
                 let meta_cache = &self.env.beatmaps;
                 let oppai = &self.env.oppai;
 
@@ -348,14 +353,18 @@ mod scores {
                     })
                     .collect::<Vec<_>>();
 
-                table_formatting(&SCORE_HEADERS, &SCORE_ALIGNS, score_arr)
+                Ok(Some(table_formatting(
+                    &SCORE_HEADERS,
+                    &SCORE_ALIGNS,
+                    score_arr,
+                )))
             }
         }
 
         const ITEMS_PER_PAGE: usize = 5;
 
         #[async_trait]
-        impl pagination::Paginate for Paginate {
+        impl<T: Scores> pagination::Paginate for Paginate<T> {
             async fn render(
                 &mut self,
                 page: u8,
@@ -363,23 +372,20 @@ mod scores {
             ) -> Result<Option<CreateReply>> {
                 let page = page as usize;
                 let start = page * ITEMS_PER_PAGE;
-                let end = self.scores.len().min(start + ITEMS_PER_PAGE);
-                if start >= end {
+                let end = start + ITEMS_PER_PAGE;
+
+                let Some(score_table) = self.to_table(start, end).await? else {
                     return Ok(None);
-                }
-                let plays = &self.scores[start..end];
-
-                let has_oppai = plays.iter().any(|p| p.pp.is_none());
-
-                let score_table = self.to_table(start, end).await;
+                };
                 let mut content = serenity::utils::MessageBuilder::new();
                 content
                     .push_line(&self.header)
                     .push_line(score_table)
-                    .push_line(format!("Page **{}/{}**", page + 1, self.total_pages()));
-                if has_oppai {
-                    content.push_line("[?] means pp was predicted by oppai-rs.");
-                };
+                    .push_line(format!(
+                        "Page **{} / {}**",
+                        page + 1,
+                        self.scores.length_fetched().as_pages(ITEMS_PER_PAGE)
+                    ));
                 let content = content.build();
 
                 Ok(Some(
@@ -388,7 +394,9 @@ mod scores {
             }
 
             fn len(&self) -> Option<usize> {
-                Some(self.total_pages())
+                let size = self.scores.length_fetched();
+                let pages = size.count().div_ceil(ITEMS_PER_PAGE);
+                Some(pages + if size.is_total() { 0 } else { 1 })
             }
         }
     }

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -109,12 +109,7 @@ pub fn handle_check_button<'a>(
 
         let guild_id = comp.guild_id;
         ScoreListStyle::Grid
-            .display_scores(
-                future::ok(scores),
-                &ctx,
-                guild_id,
-                (comp, ctx).with_header(header),
-            )
+            .display_scores(scores, &ctx, guild_id, (comp, ctx).with_header(header))
             .await
             .pls_ok();
         Ok(())

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -95,20 +95,21 @@ pub fn handle_check_button<'a>(
             return Ok(());
         }
 
+        let header = format!(
+            "Here are the scores by [`{}`](<https://osu.ppy.sh/users/{}>) on {}!",
+            user.username,
+            user.id,
+            embed.mention()
+        );
         comp.create_followup(
             &ctx,
-            CreateInteractionResponseFollowup::new().content(format!(
-                "Here are the scores by [`{}`](<https://osu.ppy.sh/users/{}>) on {}!",
-                user.username,
-                user.id,
-                embed.mention()
-            )),
+            CreateInteractionResponseFollowup::new().content(&header),
         )
         .await?;
 
         let guild_id = comp.guild_id;
         ScoreListStyle::Grid
-            .display_scores(scores, &ctx, guild_id, (comp, ctx))
+            .display_scores(scores, &ctx, guild_id, (comp, ctx).with_header(header))
             .await
             .pls_ok();
         Ok(())

--- a/youmubot-osu/src/discord/interaction.rs
+++ b/youmubot-osu/src/discord/interaction.rs
@@ -109,7 +109,12 @@ pub fn handle_check_button<'a>(
 
         let guild_id = comp.guild_id;
         ScoreListStyle::Grid
-            .display_scores(scores, &ctx, guild_id, (comp, ctx).with_header(header))
+            .display_scores(
+                future::ok(scores),
+                &ctx,
+                guild_id,
+                (comp, ctx).with_header(header),
+            )
             .await
             .pls_ok();
         Ok(())

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -1245,7 +1245,6 @@ pub(in crate::discord) async fn calculate_weighted_map_age(
         .collect::<FuturesOrdered<_>>()
         .try_collect::<Vec<_>>()
         .await?;
-    println!("Calculating score from {} scores", scores.len());
     Ok((scores
         .iter()
         .zip(scales().iter())

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -502,17 +502,13 @@ pub(crate) struct UserExtras {
 impl UserExtras {
     // Collect UserExtras from the given user.
     pub async fn from_user(env: &OsuEnv, user: &User, mode: Mode) -> Result<Self> {
-        let scores = {
-            match env
-                .client
-                .user_best(UserID::ID(user.id), |f| f.mode(mode))
-                .await
-                .pls_ok()
-            {
-                Some(v) => v.get_all().await.pls_ok().unwrap_or_else(Vec::new),
-                None => Vec::new(),
-            }
-        };
+        let scores = env
+            .client
+            .user_best(UserID::ID(user.id), |f| f.mode(mode))
+            .and_then(|v| v.get_all())
+            .await
+            .pls_ok()
+            .unwrap_or_else(Vec::new);
 
         let (length, age) = join!(
             calculate_weighted_map_length(&scores, &env.beatmaps, mode),

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -681,18 +681,14 @@ pub async fn recent(ctx: &Context, msg: &Message, mut args: Args) -> CommandResu
     let plays = osu_client.user_recent(UserID::ID(user.id), |f| f.mode(mode));
     match nth {
         Nth::All => {
-            let reply = msg
-                .reply(
-                    ctx,
-                    format!("Here are the recent plays by {}!", user.mention()),
-                )
-                .await?;
+            let header = format!("Here are the recent plays by {}!", user.mention());
+            let reply = msg.reply(ctx, &header).await?;
             style
                 .display_scores(
                     plays.try_collect::<Vec<_>>().await?,
                     ctx,
                     reply.guild_id,
-                    (reply, ctx),
+                    (reply, ctx).with_header(header),
                 )
                 .await?;
         }
@@ -758,18 +754,14 @@ pub async fn pins(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
     let plays = osu_client.user_pins(UserID::ID(user.id), |f| f.mode(mode));
     match nth {
         Nth::All => {
-            let reply = msg
-                .reply(
-                    ctx,
-                    format!("Here are the pinned plays by `{}`!", user.username),
-                )
-                .await?;
+            let header = format!("Here are the pinned plays by `{}`!", user.username);
+            let reply = msg.reply(ctx, &header).await?;
             style
                 .display_scores(
                     plays.try_collect::<Vec<_>>().await?,
                     ctx,
                     reply.guild_id,
-                    (reply, ctx),
+                    (reply, ctx).with_header(header),
                 )
                 .await?;
         }
@@ -1017,18 +1009,14 @@ pub async fn check(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
         msg.reply(&ctx, "No scores found").await?;
         return Ok(());
     }
-    let reply = msg
-        .reply(
-            &ctx,
-            format!(
-                "Here are the scores by `{}` on {}!",
-                &user.username,
-                embed.mention()
-            ),
-        )
-        .await?;
+    let header = format!(
+        "Here are the scores by `{}` on {}!",
+        &user.username,
+        embed.mention()
+    );
+    let reply = msg.reply(&ctx, &header).await?;
     style
-        .display_scores(scores, ctx, msg.guild_id, (reply, ctx))
+        .display_scores(scores, ctx, msg.guild_id, (reply, ctx).with_header(header))
         .await?;
 
     Ok(())
@@ -1130,18 +1118,14 @@ pub async fn top(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult 
             cache::save_beatmap(&env, msg.channel_id, &beatmap).await?;
         }
         Nth::All => {
-            let reply = msg
-                .reply(
-                    &ctx,
-                    format!("Here are the top plays by {}!", user.mention()),
-                )
-                .await?;
+            let header = format!("Here are the top plays by {}!", user.mention());
+            let reply = msg.reply(&ctx, &header).await?;
             style
                 .display_scores(
                     plays.try_collect::<Vec<_>>().await?,
                     ctx,
                     msg.guild_id,
-                    (reply, ctx),
+                    (reply, ctx).with_header(header),
                 )
                 .await?;
         }

--- a/youmubot-osu/src/discord/mod.rs
+++ b/youmubot-osu/src/discord/mod.rs
@@ -685,7 +685,7 @@ pub async fn recent(ctx: &Context, msg: &Message, mut args: Args) -> CommandResu
             let reply = msg.reply(ctx, &header).await?;
             style
                 .display_scores(
-                    plays.try_collect::<Vec<_>>().await?,
+                    plays.try_collect::<Vec<_>>(),
                     ctx,
                     reply.guild_id,
                     (reply, ctx).with_header(header),
@@ -758,7 +758,7 @@ pub async fn pins(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult
             let reply = msg.reply(ctx, &header).await?;
             style
                 .display_scores(
-                    plays.try_collect::<Vec<_>>().await?,
+                    plays.try_collect::<Vec<_>>(),
                     ctx,
                     reply.guild_id,
                     (reply, ctx).with_header(header),
@@ -1016,7 +1016,12 @@ pub async fn check(ctx: &Context, msg: &Message, mut args: Args) -> CommandResul
     );
     let reply = msg.reply(&ctx, &header).await?;
     style
-        .display_scores(scores, ctx, msg.guild_id, (reply, ctx).with_header(header))
+        .display_scores(
+            future::ok(scores),
+            ctx,
+            msg.guild_id,
+            (reply, ctx).with_header(header),
+        )
         .await?;
 
     Ok(())
@@ -1122,7 +1127,7 @@ pub async fn top(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult 
             let reply = msg.reply(&ctx, &header).await?;
             style
                 .display_scores(
-                    plays.try_collect::<Vec<_>>().await?,
+                    plays.try_collect::<Vec<_>>(),
                     ctx,
                     msg.guild_id,
                     (reply, ctx).with_header(header),

--- a/youmubot-osu/src/discord/server_rank.rs
+++ b/youmubot-osu/src/discord/server_rank.rs
@@ -438,7 +438,7 @@ pub async fn show_leaderboard(ctx: &Context, msg: &Message, mut args: Args) -> C
             let reply = msg.reply(&ctx, header).await?;
             style
                 .display_scores(
-                    scores.into_iter().map(|s| s.score).collect(),
+                    future::ok(scores.into_iter().map(|s| s.score).collect()),
                     ctx,
                     Some(guild),
                     (reply, ctx),

--- a/youmubot-osu/src/discord/server_rank.rs
+++ b/youmubot-osu/src/discord/server_rank.rs
@@ -30,6 +30,7 @@ use crate::{
     },
     models::Mode,
     request::UserID,
+    scores::Scores,
     Beatmap, Score,
 };
 
@@ -438,7 +439,7 @@ pub async fn show_leaderboard(ctx: &Context, msg: &Message, mut args: Args) -> C
             let reply = msg.reply(&ctx, header).await?;
             style
                 .display_scores(
-                    future::ok(scores.into_iter().map(|s| s.score).collect()),
+                    scores.into_iter().map(|s| s.score).collect::<Vec<_>>(),
                     ctx,
                     Some(guild),
                     (reply, ctx),
@@ -503,6 +504,7 @@ async fn get_leaderboard(
                     .scores(b.beatmap_id, move |f| {
                         f.user(UserID::ID(osu_id)).mode(mode_override)
                     })
+                    .and_then(|v| v.get_all())
                     .map(move |r| Some((b, op, mem.clone(), r.ok()?)))
             })
         })

--- a/youmubot-osu/src/lib.rs
+++ b/youmubot-osu/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::Arc;
 
+use futures::TryStream;
 use futures_util::lock::Mutex;
 use models::*;
 use request::builders::*;
@@ -92,39 +93,39 @@ impl OsuClient {
         r.build(self).await
     }
 
-    pub async fn user_best(
+    pub fn user_best(
         &self,
         user: UserID,
         f: impl FnOnce(&mut UserScoreRequestBuilder) -> &mut UserScoreRequestBuilder,
-    ) -> Result<Vec<Score>, Error> {
-        self.user_scores(UserScoreType::Best, user, f).await
+    ) -> impl TryStream<Ok = Score, Error = Error> {
+        self.user_scores(UserScoreType::Best, user, f)
     }
 
-    pub async fn user_recent(
+    pub fn user_recent(
         &self,
         user: UserID,
         f: impl FnOnce(&mut UserScoreRequestBuilder) -> &mut UserScoreRequestBuilder,
-    ) -> Result<Vec<Score>, Error> {
-        self.user_scores(UserScoreType::Recent, user, f).await
+    ) -> impl TryStream<Ok = Score, Error = Error> {
+        self.user_scores(UserScoreType::Recent, user, f)
     }
 
-    pub async fn user_pins(
+    pub fn user_pins(
         &self,
         user: UserID,
         f: impl FnOnce(&mut UserScoreRequestBuilder) -> &mut UserScoreRequestBuilder,
-    ) -> Result<Vec<Score>, Error> {
-        self.user_scores(UserScoreType::Pin, user, f).await
+    ) -> impl TryStream<Ok = Score, Error = Error> {
+        self.user_scores(UserScoreType::Pin, user, f)
     }
 
-    async fn user_scores(
+    fn user_scores(
         &self,
         u: UserScoreType,
         user: UserID,
         f: impl FnOnce(&mut UserScoreRequestBuilder) -> &mut UserScoreRequestBuilder,
-    ) -> Result<Vec<Score>, Error> {
+    ) -> impl TryStream<Ok = Score, Error = Error> {
         let mut r = UserScoreRequestBuilder::new(u, user);
         f(&mut r);
-        r.build(self).await
+        r.build(self.clone())
     }
 
     pub async fn score(&self, score_id: u64) -> Result<Option<Score>, Error> {

--- a/youmubot-osu/src/request/scores.rs
+++ b/youmubot-osu/src/request/scores.rs
@@ -1,0 +1,206 @@
+use std::{fmt::Display, future::Future, ops::Range};
+
+use youmubot_prelude::*;
+
+use crate::{models::Score, OsuClient};
+
+pub const MAX_SCORE_PER_PAGE: usize = 1000;
+
+/// Fetch scores given an offset.
+/// Implemented for score requests.
+pub trait FetchScores: Send {
+    /// Scores per page.
+    const SCORES_PER_PAGE: usize = MAX_SCORE_PER_PAGE;
+    /// Fetch scores given an offset.
+    fn fetch_scores(
+        &self,
+        client: &crate::OsuClient,
+        offset: usize,
+    ) -> impl Future<Output = Result<Vec<Score>>> + Send;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Size {
+    /// There might be more
+    AtLeast(usize),
+    /// All
+    Total(usize),
+}
+
+impl Display for Size {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.count())?;
+        if !self.is_total() {
+            write!(f, "+")?;
+        }
+        Ok(())
+    }
+}
+
+impl Size {
+    pub fn count(&self) -> usize {
+        match self {
+            Size::AtLeast(cnt) => *cnt,
+            Size::Total(cnt) => *cnt,
+        }
+    }
+
+    pub fn is_total(&self) -> bool {
+        match self {
+            Size::AtLeast(_) => false,
+            Size::Total(_) => true,
+        }
+    }
+
+    pub fn as_pages(self, per_page: usize) -> Size {
+        match self {
+            Size::AtLeast(a) => Size::AtLeast(a.div_ceil(per_page)),
+            Size::Total(a) => Size::Total(a.div_ceil(per_page)),
+        }
+    }
+}
+
+/// A scores stream.
+pub trait Scores: Send {
+    /// Total length of the pages.
+    fn length_fetched(&self) -> Size;
+
+    /// Whether the scores set is empty.
+    fn is_empty(&self) -> bool;
+
+    /// Get the index-th score.
+    fn get(&mut self, index: usize) -> impl Future<Output = Result<Option<&Score>>> + Send;
+
+    /// Get all scores.
+    fn get_all(self) -> impl Future<Output = Result<Vec<Score>>> + Send;
+
+    /// Get the scores between the given range.
+    fn get_range(&mut self, range: Range<usize>) -> impl Future<Output = Result<&[Score]>> + Send;
+
+    /// Find a score that matches the predicate `f`.
+    fn find<F: FnMut(&Score) -> bool + Send>(
+        &mut self,
+        f: F,
+    ) -> impl Future<Output = Result<Option<&Score>>> + Send;
+}
+
+impl Scores for Vec<Score> {
+    fn length_fetched(&self) -> Size {
+        Size::Total(self.len())
+    }
+
+    fn is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn get(&mut self, index: usize) -> impl Future<Output = Result<Option<&Score>>> + Send {
+        future::ok(self[..].get(index))
+    }
+
+    fn get_all(self) -> impl Future<Output = Result<Vec<Score>>> + Send {
+        future::ok(self)
+    }
+
+    fn get_range(&mut self, range: Range<usize>) -> impl Future<Output = Result<&[Score]>> + Send {
+        future::ok(&self[range])
+    }
+
+    async fn find<F: FnMut(&Score) -> bool + Send>(&mut self, mut f: F) -> Result<Option<&Score>> {
+        Ok(self.iter().find(|v| f(*v)))
+    }
+}
+
+/// A scores stream with a fetcher.
+pub(super) struct ScoresFetcher<T> {
+    fetcher: T,
+    client: OsuClient,
+    scores: Vec<Score>,
+    more_exists: bool,
+}
+
+impl<T: FetchScores> ScoresFetcher<T> {
+    /// Create a new Scores stream.
+    pub async fn new(client: OsuClient, fetcher: T) -> Result<Self> {
+        let mut s = Self {
+            fetcher,
+            client,
+            scores: Vec::new(),
+            more_exists: true,
+        };
+        // fetch the first page immediately.
+        s.fetch_next_page().await?;
+        Ok(s)
+    }
+}
+
+impl<T: FetchScores> Scores for ScoresFetcher<T> {
+    /// Total length of the pages.
+    fn length_fetched(&self) -> Size {
+        let count = self.len();
+        if self.more_exists {
+            Size::AtLeast(count)
+        } else {
+            Size::Total(count)
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.scores.is_empty()
+    }
+
+    /// Get the index-th score.
+    async fn get(&mut self, index: usize) -> Result<Option<&Score>> {
+        Ok(self.get_range(index..(index + 1)).await?.get(0))
+    }
+
+    /// Get all scores.
+    async fn get_all(mut self) -> Result<Vec<Score>> {
+        let _ = self.get_range(0..usize::max_value()).await?;
+        Ok(self.scores)
+    }
+
+    /// Get the scores between the given range.
+    async fn get_range(&mut self, range: Range<usize>) -> Result<&[Score]> {
+        while self.len() < range.end {
+            if !self.fetch_next_page().await? {
+                break;
+            }
+        }
+        Ok(&self.scores[range.start.min(self.len())..range.end.min(self.len())])
+    }
+
+    async fn find<F: FnMut(&Score) -> bool + Send>(&mut self, mut f: F) -> Result<Option<&Score>> {
+        let mut from = 0usize;
+        let index = loop {
+            if from == self.len() && !self.fetch_next_page().await? {
+                break None;
+            }
+            if f(&self.scores[from]) {
+                break Some(from);
+            }
+            from += 1;
+        };
+        Ok(index.map(|v| &self.scores[v]))
+    }
+}
+
+impl<T: FetchScores> ScoresFetcher<T> {
+    async fn fetch_next_page(&mut self) -> Result<bool> {
+        if !self.more_exists {
+            return Ok(false);
+        }
+        let offset = self.len();
+        let scores = self.fetcher.fetch_scores(&self.client, offset).await?;
+        if scores.len() < T::SCORES_PER_PAGE {
+            self.more_exists = false;
+        }
+        if scores.is_empty() {
+            return Ok(false);
+        }
+        self.scores.extend(scores);
+        Ok(true)
+    }
+    fn len(&self) -> usize {
+        self.scores.len()
+    }
+}


### PR DESCRIPTION
Pretty much only `top` is lazy at the moment, because the rest doesn't have a working `offset` API.
